### PR TITLE
Tracker hit counter processor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ ENDIF()
 #ADD_DEFINITIONS( "-Wno-long-long" )
 
 # include directories
-INCLUDE_DIRECTORIES( ./tracking/include  ./PID/include  ./pi0/include ./validateSim/include ./singlePhotonVal/include )
+INCLUDE_DIRECTORIES( ./tracking/include  ./PID/include  ./pi0/include ./validateSim/include ./singlePhotonVal/include ./trackerHitCtr/include)
 #INSTALL_DIRECTORY( ./include DESTINATION . FILES_MATCHING PATTERN "*.h" )
 
 # add library
@@ -90,6 +90,7 @@ AUX_SOURCE_DIRECTORY( ./PID/src library_sources )
 AUX_SOURCE_DIRECTORY( ./pi0/src library_sources )
 AUX_SOURCE_DIRECTORY( ./validateSim/src library_sources )
 AUX_SOURCE_DIRECTORY( ./singlePhotonVal/src library_sources )
+AUX_SOURCE_DIRECTORY( ./trackerHitCtr/src library_sources )
 ADD_SHARED_LIBRARY( ${PROJECT_NAME} ${library_sources} )
 INSTALL_SHARED_LIBRARY( ${PROJECT_NAME} DESTINATION lib )
 

--- a/trackerHitCtr/README.md
+++ b/trackerHitCtr/README.md
@@ -1,0 +1,2 @@
+# TrackerHitCounter
+Marlin processor which counts hits in tracker layers and reports the number of hits per unit area.

--- a/trackerHitCtr/include/TrackerHitCounter.h
+++ b/trackerHitCtr/include/TrackerHitCounter.h
@@ -1,0 +1,125 @@
+#ifndef TrackerHitCounter_h
+#define TrackerHitCounter_h 1
+
+#include "marlin/Processor.h"
+#include "DD4hep/DD4hepUnits.h"
+#include <string>
+
+/** TrackerHitCounter: Marlin processor that counts SimTrackerHits in tracker detector
+ *     elements and reports the number of hits per unit area.
+ *
+ *  S. Lukić, Jan 2018
+ */
+
+class LayerHitCounter {
+public:
+    LayerHitCounter() :
+        _area(1.), _nHits(0),
+        _nRuns(0), _nHitsRun(0), _mu2nHitsRun(0),
+        _nEvents(0), _nHitsEvent(0), _mu2nHitsEvent(0)
+
+    {}
+
+    LayerHitCounter(double area) :
+        _area(area), _nHits(0),
+        _nRuns(0), _nHitsRun(0), _mu2nHitsRun(0),
+        _nEvents(0), _nHitsEvent(0), _mu2nHitsEvent(0)
+    {}
+
+    virtual ~LayerHitCounter() {}
+
+    int getNHits() const { return _nHits; }
+    double getHitsPerCm2() const { return double(_nHits)/(_area/dd4hep::cm2); }
+
+    double getHitsPerRun() const { return double(_nHits)/_nRuns; }
+    double getStDevHitsPerRun() const { return sqrt(_mu2nHitsRun/_nRuns - pow(_nHits/_nRuns, 2)); }
+    double getHitsPerCm2PerRun() const { return getHitsPerRun()/(_area/dd4hep::cm2); }
+    double getStDevHitsPerCm2PerRun() const { return getStDevHitsPerRun()/(_area/dd4hep::cm2); }
+
+    double getHitsPerEvent() const { return double(_nHits)/_nEvents; }
+    double getStDevHitsPerEvent() const { return sqrt(_mu2nHitsEvent/_nEvents - pow(_nHits/_nEvents, 2)); }
+    double getHitsPerCm2PerEvent() const { return getHitsPerEvent()/(_area/dd4hep::cm2); }
+    double getStDevHitsPerCm2PerEvent() const { return getStDevHitsPerEvent()/(_area/dd4hep::cm2); }
+
+    bool isAreaAvailable() const { return (_area > 0.); }
+
+    void addHit() { _nHits++; _nHitsRun++; _nHitsEvent++; }
+
+    void markRun() {
+        _nRuns++;
+        _mu2nHitsRun += _nHitsRun*_nHitsRun;
+        _nHitsRun = 0;
+        /* streamlog_out(DEBUG) << "LayerHitCounter marking Run #" << _nRuns
+                << ". Nhits = " <<  _nHits << ".\n"; */
+    }
+    void markEvent() {
+        _nEvents++;
+        _mu2nHitsEvent+= _nHitsEvent*_nHitsEvent;
+        _nHitsEvent = 0;
+        /* streamlog_out(DEBUG) << "LayerHitCounter marking Run #" << _nRuns
+                << ". Nhits = " <<  _nHits << ".\n"; */
+    }
+
+private:
+    const double _area;
+    int _nHits;
+    int _nRuns;
+    int _nHitsRun;
+    double _mu2nHitsRun;
+    int _nEvents;
+    int _nHitsEvent;
+    double _mu2nHitsEvent;
+};
+
+
+typedef std::map<int, LayerHitCounter*> SystemHitCounter;
+typedef SystemHitCounter::iterator HitCtrLayerIter;
+typedef std::map<int, SystemHitCounter*> HitCtrMap;
+typedef HitCtrMap::iterator HitCtrMapIter;
+
+
+class TrackerHitCounter : public marlin::Processor {
+
+public:
+
+    virtual Processor*  newProcessor() { return new TrackerHitCounter ; }
+
+
+    TrackerHitCounter() ;
+
+    /** Read and report the areas of tracker elements.
+    *  Construct the corresponding hit counters.
+    */
+    virtual void init() ;
+
+    /// Count runs
+    virtual void processRunHeader( LCRunHeader* run ) ;
+
+    /// Count hits in subsystems
+    virtual void processEvent( LCEvent * evt ) ;
+
+    /// do nothing
+    virtual void check( LCEvent * evt ) ;
+
+    /// report hits and clean up.
+    virtual void end() ;
+
+
+protected:
+
+    void markEvent();
+    void markRun();
+
+    HitCtrMap _hitCounters{} ;
+
+    StringVec m_trkHitCollNames{} ;
+
+    int _nRun{} ;
+    int _nEvt{} ;
+} ;
+
+
+#endif // TrackerHitCounter_h
+
+
+

--- a/trackerHitCtr/src/TrackerHitCounter.cc
+++ b/trackerHitCtr/src/TrackerHitCounter.cc
@@ -46,8 +46,8 @@ void TrackerHitCounter::init() {
 
   for(dd4hep::DetElement element : detElements) {
 
-    streamlog_out(MESSAGE) << "*********************************************************************\n";
-          streamlog_out(MESSAGE) << "Detector element \'" << element.name() << "\' of type \'"
+    streamlog_out(DEBUG7) << "*********************************************************************\n";
+          streamlog_out(DEBUG7) << "Detector element \'" << element.name() << "\' of type \'"
         << element.type() << "\':\n";
 
     _hitCounters[element.id()] = new SystemHitCounter;
@@ -59,47 +59,47 @@ void TrackerHitCounter::init() {
       // We assume that layer numbering always starts from 0.
       int ilay = 0;
       for ( auto layer : layering->layers ) {
-          streamlog_out(MESSAGE) << "  Layer " << ilay+1 << ":\n";
+          streamlog_out(DEBUG7) << "  Layer " << ilay+1 << ":\n";
           double ls = layer.zHalfSensitive*2;
           double ws = layer.widthSensitive;
           int nModules = layer.ladderNumber;
           double area = ls*ws*nModules;
           (*_hitCounters.at(element.id()))[ilay] = new LayerHitCounter(area);
-          streamlog_out(MESSAGE) << "    Length of sensitive area: " << ls/dd4hep::mm << " mm\n";
-          streamlog_out(MESSAGE) << "    Width of sensitive area: " << ws/dd4hep::mm << " mm\n";
-          streamlog_out(MESSAGE) << "    Number of ladders: " << nModules << "\n";
-          streamlog_out(MESSAGE) << "    Total sensitive area: " << area/dd4hep::cm2 << " cm^2\n";
-          //streamlog_out(MESSAGE) << "    Sensors per ladder: " << layer.sensorsPerLadder << "\n";
+          streamlog_out(DEBUG7) << "    Length of sensitive area: " << ls/dd4hep::mm << " mm\n";
+          streamlog_out(DEBUG7) << "    Width of sensitive area: " << ws/dd4hep::mm << " mm\n";
+          streamlog_out(DEBUG7) << "    Number of ladders: " << nModules << "\n";
+          streamlog_out(DEBUG7) << "    Total sensitive area: " << area/dd4hep::cm2 << " cm^2\n";
+          //streamlog_out(DEBUG7) << "    Sensors per ladder: " << layer.sensorsPerLadder << "\n";
           ilay++;
       }
     }
     catch ( std::exception &e) {
-      streamlog_out(DEBUG) << "Caught exception " << e.what() << std::endl;
+      streamlog_out(DEBUG7) << "Caught exception " << e.what() << std::endl;
       try {
-            streamlog_out(DEBUG) << "Trying ZDiskPetalsData.\n";
+            streamlog_out(DEBUG7) << "Trying ZDiskPetalsData.\n";
             dd4hep::rec::ZDiskPetalsData *layering = element.extension<dd4hep::rec::ZDiskPetalsData>() ;
             // We assume that layer numbering always starts from 0.
             int ilay = 0;
             for ( auto layer : layering->layers ) {
-                streamlog_out(MESSAGE) << "  Layer " << ilay+1 << ":\n";
+                streamlog_out(DEBUG7) << "  Layer " << ilay+1 << ":\n";
                 double ls = layer.lengthSensitive;
                 double wsi = layer.widthInnerSensitive;
                 double wso = layer.widthOuterSensitive;
                 int nModules = layer.petalNumber;
                 double area = ls*(wsi+wso)*nModules/2;
                 (*_hitCounters.at(element.id()))[ilay] = new LayerHitCounter(area);
-                streamlog_out(MESSAGE) << "    Length of sensitive area: " << ls/dd4hep::mm << " mm\n";
-                streamlog_out(MESSAGE) << "    Inner width of sensitive area: " << wsi/dd4hep::mm << " mm\n";
-                streamlog_out(MESSAGE) << "    Outer width of sensitive area: " << wso/dd4hep::mm << " mm\n";
-                streamlog_out(MESSAGE) << "    Number of petals: " << nModules << "\n";
-                streamlog_out(MESSAGE) << "    Total sensitive area: " << area/dd4hep::cm2 << " cm^2\n";
-                //streamlog_out(MESSAGE) << "    Sensors per petal: " << layer.sensorsPerPetal << "\n";
+                streamlog_out(DEBUG7) << "    Length of sensitive area: " << ls/dd4hep::mm << " mm\n";
+                streamlog_out(DEBUG7) << "    Inner width of sensitive area: " << wsi/dd4hep::mm << " mm\n";
+                streamlog_out(DEBUG7) << "    Outer width of sensitive area: " << wso/dd4hep::mm << " mm\n";
+                streamlog_out(DEBUG7) << "    Number of petals: " << nModules << "\n";
+                streamlog_out(DEBUG7) << "    Total sensitive area: " << area/dd4hep::cm2 << " cm^2\n";
+                //streamlog_out(DEBUG7) << "    Sensors per petal: " << layer.sensorsPerPetal << "\n";
                 ilay++;
             }
           }
       catch ( std::exception &e1) {
-        streamlog_out(DEBUG) << "Caught exception " << e1.what() << std::endl;
-        streamlog_out(MESSAGE) << "  No layering extension in the "
+        streamlog_out(DEBUG7) << "Caught exception " << e1.what() << std::endl;
+        streamlog_out(DEBUG7) << "  No layering extension in the "
                 "detector element \'" << element.name() << "\'.\nTotal hits will be counted.\n";
         (*_hitCounters.at(element.id()))[0] = new LayerHitCounter(-1.);
       }
@@ -115,9 +115,9 @@ void TrackerHitCounter::init() {
 // Performed at the end of each run (file)
 void TrackerHitCounter::processRunHeader( LCRunHeader*) {
   _nRun++;
-  streamlog_out(MESSAGE) << "Processing run " << _nRun << "\n";
+  streamlog_out(DEBUG7) << "Processing run " << _nRun << "\n";
   markRun();
-  streamlog_out(MESSAGE) << std::endl;
+  streamlog_out(DEBUG7) << std::endl;
 }
 
 
@@ -196,7 +196,7 @@ void TrackerHitCounter::end() {
 
 
     if (hitctr->size() == 1) {
-      streamlog_out(MESSAGE) << "  Reporting total hits in detector element:\n";
+      streamlog_out(MESSAGE) << "  Reporting total hits in the detector element:\n";
     }
 
     for (auto layerpair : *hitctr ) {

--- a/trackerHitCtr/src/TrackerHitCounter.cc
+++ b/trackerHitCtr/src/TrackerHitCounter.cc
@@ -1,0 +1,253 @@
+#include "DD4hep/Detector.h"
+#include <DD4hep/DetType.h>
+#include <TrackerHitCounter.h>
+#include "DDRec/DetectorData.h"
+#include <IMPL/LCCollectionVec.h>
+#include <EVENT/SimTrackerHit.h>
+#include <UTIL/CellIDDecoder.h>
+#include <vector>
+
+using namespace marlin ;
+
+
+TrackerHitCounter aTrackerHitCounter ;
+
+
+TrackerHitCounter::TrackerHitCounter() : Processor("TrackerHitCounter"),
+    _hitCounters(), m_trkHitCollNames()
+{
+
+  // modify processor description
+  _description = "TrackerHitCounter counts SimTrackerHits in tracker detector elements "
+          "and reports the number of hits per unit area." ;
+
+  StringVec defaultTrkHitCollections;
+  defaultTrkHitCollections.push_back(std::string("VXDCollection"));
+  defaultTrkHitCollections.push_back(std::string("SITCollection"));
+  defaultTrkHitCollections.push_back(std::string("FTDCollection"));
+  defaultTrkHitCollections.push_back(std::string("TPCCollection"));
+  defaultTrkHitCollections.push_back(std::string("SETCollection"));
+
+  registerProcessorParameter("TrkHitCollections" ,
+                             "Tracker hit collections that will be analysed",
+                             m_trkHitCollNames ,
+                             defaultTrkHitCollections ) ;
+}
+
+void TrackerHitCounter::init() { 
+
+  // usually a good idea to
+  printParameters() ;
+
+  // v01-19-05 namespace
+  dd4hep::Detector& theDetector = dd4hep::Detector::getInstance();
+
+  const std::vector< dd4hep::DetElement > &detElements = theDetector.detectors("tracker", true);
+
+  for(dd4hep::DetElement element : detElements) {
+
+    streamlog_out(MESSAGE) << "*********************************************************************\n";
+          streamlog_out(MESSAGE) << "Detector element \'" << element.name() << "\' of type \'"
+        << element.type() << "\':\n";
+
+    _hitCounters[element.id()] = new SystemHitCounter;
+
+    try {
+      streamlog_out(DEBUG) << "Trying ZPlanarData.\n";
+      dd4hep::rec::ZPlanarData* layering = element.extension<dd4hep::rec::ZPlanarData>() ;
+
+      // We assume that layer numbering always starts from 0.
+      int ilay = 0;
+      for ( auto layer : layering->layers ) {
+          streamlog_out(MESSAGE) << "  Layer " << ilay+1 << ":\n";
+          double ls = layer.zHalfSensitive*2;
+          double ws = layer.widthSensitive;
+          int nModules = layer.ladderNumber;
+          double area = ls*ws*nModules;
+          (*_hitCounters.at(element.id()))[ilay] = new LayerHitCounter(area);
+          streamlog_out(MESSAGE) << "    Length of sensitive area: " << ls/dd4hep::mm << " mm\n";
+          streamlog_out(MESSAGE) << "    Width of sensitive area: " << ws/dd4hep::mm << " mm\n";
+          streamlog_out(MESSAGE) << "    Number of ladders: " << nModules << "\n";
+          streamlog_out(MESSAGE) << "    Total sensitive area: " << area/dd4hep::cm2 << " cm^2\n";
+          //streamlog_out(MESSAGE) << "    Sensors per ladder: " << layer.sensorsPerLadder << "\n";
+          ilay++;
+      }
+    }
+    catch ( std::exception &e) {
+      streamlog_out(DEBUG) << "Caught exception " << e.what() << std::endl;
+      try {
+            streamlog_out(DEBUG) << "Trying ZDiskPetalsData.\n";
+            dd4hep::rec::ZDiskPetalsData *layering = element.extension<dd4hep::rec::ZDiskPetalsData>() ;
+            // We assume that layer numbering always starts from 0.
+            int ilay = 0;
+            for ( auto layer : layering->layers ) {
+                streamlog_out(MESSAGE) << "  Layer " << ilay+1 << ":\n";
+                double ls = layer.lengthSensitive;
+                double wsi = layer.widthInnerSensitive;
+                double wso = layer.widthOuterSensitive;
+                int nModules = layer.petalNumber;
+                double area = ls*(wsi+wso)*nModules/2;
+                (*_hitCounters.at(element.id()))[ilay] = new LayerHitCounter(area);
+                streamlog_out(MESSAGE) << "    Length of sensitive area: " << ls/dd4hep::mm << " mm\n";
+                streamlog_out(MESSAGE) << "    Inner width of sensitive area: " << wsi/dd4hep::mm << " mm\n";
+                streamlog_out(MESSAGE) << "    Outer width of sensitive area: " << wso/dd4hep::mm << " mm\n";
+                streamlog_out(MESSAGE) << "    Number of petals: " << nModules << "\n";
+                streamlog_out(MESSAGE) << "    Total sensitive area: " << area/dd4hep::cm2 << " cm^2\n";
+                //streamlog_out(MESSAGE) << "    Sensors per petal: " << layer.sensorsPerPetal << "\n";
+                ilay++;
+            }
+          }
+      catch ( std::exception &e1) {
+        streamlog_out(DEBUG) << "Caught exception " << e1.what() << std::endl;
+        streamlog_out(MESSAGE) << "  No layering extension in the "
+                "detector element \'" << element.name() << "\'.\nTotal hits will be counted.\n";
+        (*_hitCounters.at(element.id()))[0] = new LayerHitCounter(-1.);
+      }
+    }
+
+
+    streamlog_out(MESSAGE) << "\n    Added " << _hitCounters.at(element.id())->size()
+            << " hit counters for subsystem \'" << element.name() << "\'.\n\n";
+  }
+}
+
+
+// Performed at the end of each run (file)
+void TrackerHitCounter::processRunHeader( LCRunHeader*) {
+  _nRun++;
+  streamlog_out(MESSAGE) << "Processing run " << _nRun << "\n";
+  markRun();
+  streamlog_out(MESSAGE) << std::endl;
+}
+
+
+void TrackerHitCounter::processEvent( LCEvent * evt) {
+
+  _nEvt++;
+
+  for (auto collname : m_trkHitCollNames) {
+
+    streamlog_out(DEBUG) << "Looking into collection " << collname << "\n";
+    LCCollectionVec *col = dynamic_cast<LCCollectionVec*>(evt->getCollection(collname));
+    CellIDDecoder<SimTrackerHit> decoder(col);
+
+    for (auto lcobj : (*col)) {
+
+      SimTrackerHit* hit = dynamic_cast<SimTrackerHit*>(lcobj);
+
+      if(!hit) {
+        streamlog_out(WARNING) << "Collection " << collname << " contains objects "
+            "of type other than SimTrackerHit!\nSkipping collection.\n";
+        break;
+      }
+
+      int nsys = decoder(hit)["system"];
+      streamlog_out(DEBUG) << "Found hit belonging to system #" << nsys << "\n";
+      HitCtrMapIter hcmit = _hitCounters.find(nsys);
+
+      if (hcmit == _hitCounters.end()) {
+        streamlog_out(WARNING) << "Hit belongs to a system that is not analysed.\n";
+      }
+      else {
+        SystemHitCounter *shc = hcmit->second;
+        if (shc->size() == 1) {
+          shc->at(0)->addHit();
+        }
+        else {
+          int nLayer = decoder(hit)["layer"];
+          HitCtrLayerIter hclit = shc->find(nLayer);
+          if (hclit == shc->end()) {
+            streamlog_out(ERROR) << "Hit in system ID=" << hcmit->first
+                 << " belongs to layer number " << nLayer << ". Out of range!\n"
+                    "  This should only happen if the xml detector description\n"
+                    "  is different than the one used in the simulation.\n";
+          }
+          else {
+            hclit->second->addHit();
+          }
+        }
+      }
+
+    } // Loop over hits in collection
+
+  } // Loop over collections
+
+  markEvent();
+
+}
+
+
+void TrackerHitCounter::check( LCEvent *  ) { }
+
+
+void TrackerHitCounter::end() {
+
+  streamlog_out(MESSAGE) << "******************************************************\n";
+  streamlog_out(MESSAGE) << "REPORT: \n";
+
+  dd4hep::Detector& theDetector = dd4hep::Detector::getInstance();
+  const std::vector< dd4hep::DetElement > &detElements = theDetector.detectors("tracker", true);
+
+  for(dd4hep::DetElement element : detElements) {
+
+    streamlog_out(MESSAGE) << "-----------------------------------------\n"
+        "Subsystem : " << element.name() << "\n";
+    auto hitctr = _hitCounters.at(element.id());
+
+
+    if (hitctr->size() == 1) {
+      streamlog_out(MESSAGE) << "  Reporting total hits in detector element:\n";
+    }
+
+    for (auto layerpair : *hitctr ) {
+
+        auto layerctr = layerpair.second;
+        streamlog_out(MESSAGE) << "  Layer " << layerpair.first+1 << ": "
+            << layerctr->getNHits() << " hits.\n";
+        streamlog_out(MESSAGE) << "    (" << layerctr->getHitsPerRun() << " +- "
+                  << layerctr->getStDevHitsPerRun() << ") hits/run.\n";
+        streamlog_out(MESSAGE) << "    (" << layerctr->getHitsPerEvent() << " +- "
+                  << layerctr->getStDevHitsPerEvent() << ") hits/event.\n";
+
+        if (layerctr->isAreaAvailable()) {
+          streamlog_out(MESSAGE) << "    (" << layerctr->getHitsPerCm2PerRun() << " +- "
+                  << layerctr->getStDevHitsPerCm2PerRun() << ") hits/cm^2/run.\n";
+          streamlog_out(MESSAGE) << "    (" << layerctr->getHitsPerCm2PerEvent() << " +- "
+                  << layerctr->getStDevHitsPerCm2PerEvent() << ") hits/cm^2/event.\n";
+        }
+    }
+
+    streamlog_out(MESSAGE) << "\n";
+  }
+  streamlog_out(MESSAGE) << "Analysed a total of " << _nEvt << " events in " << _nRun << " runs.\n";
+  streamlog_out(MESSAGE) << "******************************************************\n";
+
+
+  // Clean up
+  for (auto systempair : _hitCounters) {
+        for (auto layerpair : *(systempair.second) ) {
+            delete layerpair.second;
+        }
+        delete systempair.second;
+    }
+    _hitCounters.clear();
+
+}
+
+
+void TrackerHitCounter::markRun() {
+    for (auto sysCtr : _hitCounters) {
+        for (auto layerCtr : *sysCtr.second) {
+            layerCtr.second->markRun();
+        }
+    }
+}
+
+void TrackerHitCounter::markEvent() {
+    for (auto sysCtr : _hitCounters) {
+        for (auto layerCtr : *sysCtr.second) {
+            layerCtr.second->markEvent();
+        }
+    }
+}
+

--- a/trackerHitCtr/xml/TrackerHitCounter.xml
+++ b/trackerHitCtr/xml/TrackerHitCounter.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<marlin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ilcsoft.desy.de/marlin/marlin.xsd">
+  <execute>
+
+    <!-- ========== setup  ========== -->
+    <processor name="MyAIDAProcessor"/>
+    <processor name="InitDD4hep"/>
+
+    <!-- ========== track dE/dx  ========== -->
+    <processor name="MyTrackerHitCounter"/>
+
+  </execute>
+
+
+  <global>
+    <parameter name="LCIOInputFiles">
+      pairs_1bx_1321.slcio
+      pairs_1bx_1322.slcio
+      </parameter>
+    <!-- Limit the number of processed records (run+evt): -->
+    <parameter name="MaxRecordNumber" value="-1" />
+    <parameter name="SkipNEvents" value="0" />
+    <parameter name="SupressCheck" value="false" />  
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE  </parameter>
+    <parameter name="RandomSeed" value="1234567890" />
+  </global>
+
+
+  <processor name="MyAIDAProcessor" type="AIDAProcessor">
+    <!--Processor that handles AIDA files. Creates on directory per processor.  Processors only need to create and fill the histograms, clouds and tuples. Needs to be the first ActiveProcessor-->
+    <!-- compression of output file 0: false >0: true (default) -->
+    <parameter name="Compress" type="int" value="1"/>
+    <!-- filename without extension-->
+    <parameter name="FileName" type="string" value="histograms"/>
+    <!-- type of output file xml (default) or root ( only OpenScientist)-->
+    <parameter name="FileType" type="string" value="root "/>
+  </processor>
+
+
+  <processor name="InitDD4hep" type="InitializeDD4hep">
+    <!--InitializeDD4hep reads a compact xml file and initializes the DD4hep::LCDD object-->
+    <!--Name of the DD4hep compact xml file to load-->
+    <parameter name="DD4hepXMLFile" type="string"> ILD_l5_v02/ILD_l5_v02.xml </parameter>
+  </processor>
+
+
+
+
+  <!-- == Tracker area reader == -->
+  <processor name="MyTrackerHitCounter" type="TrackerHitCounter">
+
+  </processor>
+
+
+</marlin>


### PR DESCRIPTION

BEGINRELEASENOTES
- Added TrackerHitCounter Marlin processor. This is a simple tool to count hits in the tracker elements. It reports the number of hits per run, per event and, where available, per unit area.

ENDRELEASENOTES