### PR TITLE
SimCalorimeterHit stepLength monitor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ ENDIF()
 #ADD_DEFINITIONS( "-Wno-long-long" )
 
 # include directories
-INCLUDE_DIRECTORIES( ./tracking/include  ./PID/include  ./pi0/include ./validateSim/include ./singlePhotonVal/include ./trackerHitCtr/include)
+INCLUDE_DIRECTORIES( ./tracking/include  ./PID/include  ./pi0/include ./validateSim/include ./singlePhotonVal/include ./trackerHitCtr/include ./stepLength/include)
 #INSTALL_DIRECTORY( ./include DESTINATION . FILES_MATCHING PATTERN "*.h" )
 
 # add library
@@ -91,6 +91,7 @@ AUX_SOURCE_DIRECTORY( ./pi0/src library_sources )
 AUX_SOURCE_DIRECTORY( ./validateSim/src library_sources )
 AUX_SOURCE_DIRECTORY( ./singlePhotonVal/src library_sources )
 AUX_SOURCE_DIRECTORY( ./trackerHitCtr/src library_sources )
+AUX_SOURCE_DIRECTORY( ./stepLength/src library_sources )
 ADD_SHARED_LIBRARY( ${PROJECT_NAME} ${library_sources} )
 INSTALL_SHARED_LIBRARY( ${PROJECT_NAME} DESTINATION lib )
 

--- a/stepLength/include/StepLength.h
+++ b/stepLength/include/StepLength.h
@@ -1,0 +1,88 @@
+#ifndef StepLength_h
+#define StepLength_h 1
+
+#include <marlin/Processor.h>
+#include <marlin/Global.h>
+
+#include <EVENT/LCCollection.h>
+#include <EVENT/SimCalorimeterHit.h>
+
+#include "TROOT.h"
+#include <TTree.h>
+#include <vector>
+#include "lcio.h"
+#include <string>
+#include <iostream>
+#include <algorithm>
+
+using namespace lcio ;
+using namespace marlin ;
+using namespace std ;
+
+/** StepLength processor
+*/
+
+class StepLength : public Processor {
+  
+ public:
+ 
+
+  virtual Processor*  newProcessor() { return new StepLength ; }
+  
+  
+  StepLength() ;
+  StepLength(const StepLength&) = delete;
+  StepLength& operator=(const StepLength&) = delete;
+
+  
+  /** Called at the begin of the job before anything is read.
+   * Use to initialize the processor, e.g. book histograms.
+   */
+  virtual void init();
+
+  /** Called for every run.
+   */
+  virtual void processRunHeader( LCRunHeader* run ) ;
+  
+  /** Called for every event - the working horse.
+   */
+  virtual void processEvent( LCEvent * evt ) ; 
+  
+  
+  virtual void check( LCEvent * evt ) ; 
+  
+  
+  /** Called after data processing for clean up.
+   */
+  virtual void end() ;
+
+  /** Initialise the ROOT TTRee.
+   */
+  void initTree(void) ;
+
+  /** Initialise the all the vectors.
+   */
+  void clearVec(void) ;
+
+  /** Initialise the all the parameters for marlin.
+   */
+  void initParameters(void) ;
+
+ protected:
+
+  /** Input collection name.
+   */
+  StringVec   _simCaloHitCollectionNames = {};
+
+  int nEvt = 0;
+
+ private:
+
+  TTree *StepTree = NULL;
+  vector<int> PDG  = {};
+  vector<float> stepLength  = {};
+
+} ;
+
+
+#endif

--- a/stepLength/script/README.md
+++ b/stepLength/script/README.md
@@ -1,0 +1,14 @@
+## To check the simulation SimCalorimeterHit stepLength
+
+### after simulation, one could run the following Marlin job to generate the stepLength root tree file with his simulation input.
+ 
+```shell
+Marlin StepLength.xml \
+  --global.LCIOInputFiles=MySimulation_step_length_max_5.0_mm_10evts_SIM.slcio \
+  --MyAIDAProcessor.FileName=stepLength
+```
+
+```shell
+root stepLength.root
+StepLength->Draw("stepLength", "PDG==11")
+```

--- a/stepLength/script/StepLength.xml
+++ b/stepLength/script/StepLength.xml
@@ -1,0 +1,37 @@
+<marlin>
+
+  <execute>
+    <processor name="MyAIDAProcessor"/>
+    <processor name="SimCaloHitsStepLength"/>
+  </execute>
+
+  <global>
+    <parameter name="LCIOInputFiles">
+      ./MySimulation_step_length_max_5.0_mm_10evts_SIM.slcio
+    </parameter>
+    <parameter name="MaxRecordNumber" value="0"/>
+    <parameter name="SkipNEvents" value="0"/>
+    <parameter name="SupressCheck" value="false"/>
+    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> MESSAGE </parameter>
+    <parameter name="RandomSeed" value="1234567890" />
+  </global>
+
+
+  <processor name="MyAIDAProcessor" type="AIDAProcessor">
+    <!--Processor that handles AIDA files. Creates on directory per processor.  Processors only need to create and fill the histograms, clouds and tuples. Needs to be the first ActiveProcessor-->
+    <!-- compression of output file 0: false >0: true (default) -->
+    <parameter name="Compress" type="int" value="1"/>
+    <!-- filename without extension-->
+    <parameter name="FileName" type="string" value="stepLength"/>
+    <!-- type of output file xml (default) or root ( only OpenScientist)-->
+    <parameter name="FileType" type="string" value="root "/>
+  </processor>
+
+ <processor name="SimCaloHitsStepLength" type="StepLength">
+  <!--Names of the SimCalorimeterHits input collection-->
+  <parameter name="SimCalorimeterHitCollections" type="StringVec" lcioInType="SimCalorimeterHit">HCalBarrelRPCHits HcalBarrelRegCollection  </parameter>
+  <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+  <!--parameter name="Verbosity" type="string">DEBUG </parameter-->
+</processor>
+
+</marlin>

--- a/stepLength/src/StepLength.cc
+++ b/stepLength/src/StepLength.cc
@@ -1,0 +1,124 @@
+#include "StepLength.h"
+#include <GeometryUtil.h>
+
+StepLength aStepLength ;
+
+void StepLength::initTree(void) {
+  streamlog_out(DEBUG4) << " initialise stepTree " << std::endl;
+
+  StepTree = new TTree("StepLength","StepLength");
+  StepTree->Branch("PDG",&PDG) ;
+  StepTree->Branch("stepLength",&stepLength) ;
+
+  streamlog_out(DEBUG4) << " initialise StepTree " << std::endl;
+
+}
+
+
+void StepLength::clearVec(void) {
+
+  PDG.clear();  stepLength.clear();
+
+}
+
+
+void StepLength::initParameters(void) {
+
+  // register steering parameters: name, description, class-variable, default value
+
+  StringVec exampleSimHits ;
+  exampleSimHits.push_back("HCalBarrelRPCHits") ;
+  exampleSimHits.push_back("HcalBarrelRegCollection") ;
+  
+  registerInputCollections( LCIO::SIMCALORIMETERHIT,
+			   "SimCalorimeterHitCollections" ,
+			   "Names of the SimCalorimeterHits input collection"  ,
+			   _simCaloHitCollectionNames ,
+			    exampleSimHits ) ;
+}
+
+
+StepLength::StepLength() : Processor("StepLength") {
+
+  // modify processor description
+  _description = "StepLength does whatever it does ..." ;
+
+  initParameters() ;
+
+}
+
+
+void StepLength::init() { 
+
+  streamlog_out(DEBUG) << "   StepLength::init() called  "  << std::endl ;
+
+  // usually a good idea to
+  printParameters() ;
+  nEvt = 0;
+
+  gROOT->ProcessLine("#include <vector>");
+  //TApplication theApp("tapp", 0, 0);
+
+}
+
+void StepLength::processRunHeader( LCRunHeader* run) { 
+   streamlog_out(MESSAGE) << " start processing run "<<run->getRunNumber() << std::endl;
+} 
+
+void StepLength::processEvent( LCEvent * evt ) { 
+
+  streamlog_out(MESSAGE) << " start processing event "<<evt->getEventNumber() << std::endl;
+
+  if( isFirstEvent() ) { 
+    streamlog_out(DEBUG4) << " This is the first event " << std::endl;
+
+    initTree() ;
+
+  }
+
+  clearVec() ;
+
+ 
+  for( unsigned i=0,iN=_simCaloHitCollectionNames.size() ; i<iN ; ++i){
+
+    const LCCollection* col = 0 ;
+    try{ col = evt->getCollection( _simCaloHitCollectionNames[i] ) ; } catch(DataNotAvailableException&) {}
+    if( col ){
+      streamlog_out(DEBUG4) << " We examine collection " << _simCaloHitCollectionNames[i] << " with " << col->getNumberOfElements() << " hits " << std::endl;
+	
+      for( int j = 0, jN = col->getNumberOfElements() ; j<jN ; ++j ) {
+	SimCalorimeterHit* simHit = (SimCalorimeterHit*) col->getElementAt( j ) ;
+
+	for( int k = 0, kN = simHit->getNMCContributions() ; k<kN ; ++k ) {
+	  int NMCC_PDG = simHit->getPDGCont(k) ;
+	  float NMCC_stepLength = simHit->getLengthCont(k) ;
+
+	  PDG.push_back(NMCC_PDG);
+	  stepLength.push_back(NMCC_stepLength);
+	}
+
+      }
+      
+    }
+  }
+
+    
+  StepTree->Fill();
+
+  nEvt++;
+  
+  cout << " event " << nEvt << std::endl ;
+  
+}
+
+
+
+void StepLength::check( LCEvent * evt ) { 
+   streamlog_out(DEBUG4) << " StepLength::check event "
+			 << evt->getEventNumber() <<std::endl;
+}
+
+
+void StepLength::end(){ 
+  streamlog_out(DEBUG4) << " StepLength::end() "<<std::endl;
+}


### PR DESCRIPTION

BEGINRELEASENOTES
- Added Marlin processor to generate SimCalorimeterHit stepLength information
    - could draw stepLength base on PDG code information.
    - a tool will help sub-detector group to monitor or validate the calorimeter step_length_max configuration.

ENDRELEASENOTES