### PR TITLE
update the monitoring information of tracking. 

### DIFF
--- a/tracking/include/DDDiagnostics.h
+++ b/tracking/include/DDDiagnostics.h
@@ -129,8 +129,6 @@ class DDDiagnostics : public Processor {
   int OutVxdBkgHit = 0;
   int OutVxdPhysHit = 0;
 
-  int ghostCounter = 0;
-
   float _bField = 0.0;
 
   bool _trkEffOn = false;
@@ -186,20 +184,6 @@ class DDDiagnostics : public Processor {
   vector<float> recoTanLambdaError = {};
   vector<float> siTrksCosTheta = {};
 
-  TTree *GhostTree = NULL;
-  vector<float> ghostPt = {};
-  vector<float> ghostCosTheta = {};
-  vector<float> ghostTrkChi2OverNdof  = {};
-  vector<float> ghostWgt = {};
-  vector<int>   ghost_hits = {};
-  vector<int>   generatorStatus = {};
-  vector<int>   DecayedInTracker = {};
-  vector<float> doubleCountingPt = {};
-  vector<float> doubleCountingCosTheta = {};
-  vector<float> BadTrksD0  = {};
-  vector<float> BadTrksZ0  = {};
-
-
   int MarlinTracks = 0;
   int BCalParts = 0;
   int BCalCls = 0;
@@ -228,15 +212,6 @@ class DDDiagnostics : public Processor {
   TH1F *hist_thm_t  = NULL;
   TH1F *hist_thm_f  = NULL;
 
-  TH1F *hist_pt_allMarTrk  = NULL;
-  TH1F *hist_pt_fakeMarTrk  = NULL;
-  TH1F *hist_p_allMarTrk  = NULL;
-  TH1F *hist_p_fakeMarTrk  = NULL;
-  TH1F *hist_th_allMarTrk  = NULL;
-  TH1F *hist_th_fakeMarTrk  = NULL;
-  TH1F *hist_thm_allMarTrk  = NULL;
-  TH1F *hist_thm_fakeMarTrk  = NULL;
-
   TCanvas *pulls = NULL;
   TCanvas *residuals = NULL;
   TCanvas *eff = NULL;
@@ -250,11 +225,6 @@ class DDDiagnostics : public Processor {
   TGraphAsymmErrors *gp = NULL;
   TGraphAsymmErrors *gth = NULL;
   TGraphAsymmErrors *gthm = NULL;
-
-  TGraphAsymmErrors *gptfake = NULL;
-  TGraphAsymmErrors *gpfake = NULL;
-  TGraphAsymmErrors *gthfake = NULL;
-  TGraphAsymmErrors *gthmfake = NULL;
 
   double PI    = 3.1415926535897;
   double TWOPI = 6.2831853071794;

--- a/tracking/include/DDDiagnostics.h
+++ b/tracking/include/DDDiagnostics.h
@@ -119,9 +119,6 @@ class DDDiagnostics : public Processor {
   std::string _sitTrkHitRelations = "";
   std::string _vxdTrackerHits = "";
   std::string _vxdTrkHitRelations = "";
-  std::string _BCALParticleCollectionName = "";
-  std::string _BCALClusterCollectionName = "";
-  std::string _pandoraPFOs = "";
 
   int nEvt = 0;
   int OutSitBkgHit = 0;
@@ -149,18 +146,14 @@ class DDDiagnostics : public Processor {
   TTree *EvalTree = NULL;
   vector<int> foundTrk = {};
   vector<int> TrackSiHits = {};
-  vector<int> SiHitsSiTrk  = {};
   vector<int> MarlinTrkHits  = {};
   vector<int> VXDHits  = {};
   vector<int> SITHits  = {};
   vector<int> FTDHits  = {};
   vector<int> TPCHits  = {};
   vector<float> foundTrkChi2OverNdof  = {};
-  vector<float> CluChi2OverNdof  = {};
-  vector<float> SiTrkChi2OverNdof  = {};
   vector<float> PtReco = {};
   vector<float> CosThetaReco = {};
-  vector<float> SiTrksPt = {};
   vector<float> PtMCP = {};
   vector<float> CosThetaMCP = {};
   vector<float> Wgt = {};
@@ -177,17 +170,11 @@ class DDDiagnostics : public Processor {
   vector<float> recoOmega = {};
   vector<float> recoPhi = {};
   vector<float> recoTanLambda = {};
-  vector<float> recoD0error = {};
-  vector<float> recoZ0error = {};
   vector<float> recoOmegaError = {};
   vector<float> recoPhiError = {};
   vector<float> recoTanLambdaError = {};
-  vector<float> siTrksCosTheta = {};
 
   int MarlinTracks = 0;
-  int BCalParts = 0;
-  int BCalCls = 0;
-  int pfos  = 0;
 
   TH1F *OmegaPull = NULL;
   TH1F *PhiPull = NULL;
@@ -215,9 +202,7 @@ class DDDiagnostics : public Processor {
   TCanvas *pulls = NULL;
   TCanvas *residuals = NULL;
   TCanvas *eff = NULL;
-  TCanvas *Rfake = NULL;
   TCanvas *effPM = NULL;
-  TCanvas *RfakePM = NULL;
 
   TF1 *myfunc  = NULL;
 

--- a/tracking/include/DDDiagnostics.h
+++ b/tracking/include/DDDiagnostics.h
@@ -115,7 +115,7 @@ class DDDiagnostics : public Processor {
   std::string _mcParticleCollectionName = "";
   StringVec   _simTrkHitCollectionNames = {};
   std::string _trackColName = "";
-  std::string _sitSpacePoints = "";
+  std::string _sitTrackerHits = "";
   std::string _sitTrkHitRelations = "";
   std::string _vxdTrackerHits = "";
   std::string _vxdTrkHitRelations = "";

--- a/tracking/src/DDDiagnostics.cc
+++ b/tracking/src/DDDiagnostics.cc
@@ -66,24 +66,6 @@ void DDDiagnostics::initTree(void) {
   EvalTree->Branch("recoTanLambdaError",&recoTanLambdaError) ;
   EvalTree->Branch("MarlinTrkHits",&MarlinTrkHits) ;
 
-  streamlog_out(DEBUG4) << " initialise EvalTree " << std::endl;
-
-  GhostTree = new TTree("GhostTree","GhostTree");
-  GhostTree->Branch("ghostPt",&ghostPt) ;
-  GhostTree->Branch("ghostCosTheta",&ghostCosTheta) ;
-  GhostTree->Branch("ghostTrkChi2OverNdof",&ghostTrkChi2OverNdof);
-  GhostTree->Branch("ghostWgt",&ghostWgt) ;
-  GhostTree->Branch("ghost_hits",&ghost_hits) ;
-  GhostTree->Branch("doubleCountingPt",&doubleCountingPt) ;
-  GhostTree->Branch("doubleCountingCosTheta",&doubleCountingCosTheta) ;
-  GhostTree->Branch("BadTrksD0",&BadTrksD0) ;
-  GhostTree->Branch("BadTrksZ0",&BadTrksZ0) ;
-  GhostTree->Branch("generatorStatus",&generatorStatus) ;
-  GhostTree->Branch("DecayedInTracker",&DecayedInTracker) ;
-
-  //EvalTree->SetMaxTreeSize(1000000000LL); // ROOT file size 1GB
-  //GhostTree->SetMaxTreeSize(1000000000LL);
-
 }
 
 void DDDiagnostics::initHist(void) {
@@ -116,27 +98,11 @@ void DDDiagnostics::initHist(void) {
   hist_thm_t  = new TH1F( "hist_thm_t", "Cos theta distributions of true tracks", 21, -1., 1. ) ;
   hist_thm_f  = new TH1F( "hist_thm_f", "Cos theta distribution of found tracks", 21, -1., 1. ) ;
 
-  hist_pt_allMarTrk  = new TH1F( "hist_pt_allMarTrk", "Pt distributions of all MarlinTrktracks", nBins , bins ) ;
-  hist_pt_fakeMarTrk  = new TH1F( "hist_pt_fakeMarTrk", "Pt distribution of fake MarlinTrktracks", nBins , bins ) ;
-
-  hist_p_allMarTrk  = new TH1F( "hist_p_allMarTrk", "Momentum distributions of all MarlinTrktracks", 100 , 0.5, 100.5 ) ;
-  hist_p_fakeMarTrk  = new TH1F( "hist_p_fakeMarTrk", "Momentum distribution of fake MarlinTrktracks", 100 , 0.5, 100.5 ) ;
-
-  hist_th_allMarTrk  = new TH1F( "hist_th_allMarTrk", "Cos theta distributions of all MarlinTrktracks", 10, 0., 1. ) ;
-  hist_th_fakeMarTrk  = new TH1F( "hist_th_fakeMarTrk", "Cos theta distribution of fake MarlinTrktracks", 10, 0., 1. ) ;
-
-  hist_thm_allMarTrk  = new TH1F( "hist_thm_allMarTrk", "Cos theta distributions of all MarlinTrktracks", 21, -1., 1. ) ;
-  hist_thm_fakeMarTrk  = new TH1F( "hist_thm_fakeMarTrk", "Cos theta distribution of fake MarlinTrktracks", 21, -1., 1. ) ;
-
-
   pulls = new TCanvas("pulls","Track par. pulls",800,800);
   residuals =  new TCanvas("residuals","Track par. residuals",800,800);
 
   eff = new TCanvas("eff","Trk Eff",800,800);
   effPM = new TCanvas("effPM","Trk Eff",800,800);
-
-  Rfake = new TCanvas("Rfake","MarlinTrkTracks fake rate",800,800);
-  RfakePM = new TCanvas("RfakePM","MarlinTrkTracks fake rate",800,800);
 
   myfunc = new TF1("myfunc","gaus(0)");
 
@@ -145,17 +111,9 @@ void DDDiagnostics::initHist(void) {
   gth = new TGraphAsymmErrors() ;
   gthm = new TGraphAsymmErrors() ;
 
-  gptfake = new TGraphAsymmErrors() ;
-  gpfake = new TGraphAsymmErrors() ;
-  gthfake = new TGraphAsymmErrors() ;
-  gthmfake = new TGraphAsymmErrors() ;
-
 }
 
 void DDDiagnostics::fillCanvas(void) {
-
-  //TApplication theApp("tapp", 0, 0);
-  // Writing a canvas with the pulls of the track parameters
 
   pulls->Divide(3,2);
   pulls->cd(1);
@@ -248,66 +206,6 @@ void DDDiagnostics::fillCanvas(void) {
   gthm->Write("gthM");
   effPM->Write();
 
-
-  Rfake->Divide(1,2);
-
-  Rfake->cd(1);
-  gPad->SetLogx() ;
-  gptfake->Divide( hist_pt_fakeMarTrk , hist_pt_allMarTrk , "v" ) ;
-  gptfake->SetMarkerColor( kRed ) ;
-  gptfake->SetLineColor( kRed ) ;
-  gptfake->GetYaxis()->SetTitle( "Fraction of fake tracks" );
-  gptfake->GetXaxis()->SetTitle( "p_{t} [GeV]" );
-  gptfake->Draw("AP");
-
-  Rfake->cd(2);
-  gthfake->Divide( hist_th_fakeMarTrk , hist_th_allMarTrk , "v" ) ;
-  gthfake->SetMarkerColor( kRed ) ;
-  gthfake->SetLineColor( kRed ) ;
-  gthfake->GetYaxis()->SetTitle( "Fraction of fake tracks" );
-  gthfake->GetXaxis()->SetTitle( "cos(#theta)" );
-  gthfake->Draw("AP");
-
-
-  gptfake->Write("gptfake");
-  gthfake->Write("gthfake");
-  Rfake->Write();
-
-  RfakePM->Divide(1,2);
-
-  RfakePM->cd(1);
-  gPad->SetLogx() ;
-  gpfake->Divide( hist_p_fakeMarTrk , hist_p_allMarTrk , "v" ) ;
-  gpfake->SetMarkerColor( kRed ) ;
-  gpfake->SetLineColor( kRed ) ;
-  gpfake->GetYaxis()->SetTitle( "Fraction of fake tracks" );
-  gpfake->GetXaxis()->SetTitle( "Momentum [GeV]" );
-  gpfake->Draw("AP");
-
-  RfakePM->cd(2);
-  gthmfake->Divide( hist_thm_fakeMarTrk , hist_thm_allMarTrk , "v" ) ;
-  gthmfake->SetMarkerColor( kRed ) ;
-  gthmfake->SetLineColor( kRed ) ;
-  gthmfake->GetYaxis()->SetTitle( "Fraction of fake tracks" );
-  gthmfake->GetXaxis()->SetTitle( "cos(#theta)" );
-  gthmfake->Draw("AP");
-
-
-  gpfake->Write("gpfake");
-  gthmfake->Write("gthmfake");
-  RfakePM->Write();
-
-  streamlog_out(DEBUG4) << " Number of ghost being related to an MCParticle " << ghostCounter << std::endl ;
-  /*
-  TApplication theApp("tapp", 0, 0);
-
-  TControlBar bar2("vertical");
-  bar2.AddButton("Residuals","residuals->Draw()", "...  >>Residuals<<");
-  bar2.Show();
-  theApp.Run();
-  //theApp.SetReturnFromRun(true);
-  */
-
 }
 
 void DDDiagnostics::clearVec(void) {
@@ -316,11 +214,8 @@ void DDDiagnostics::clearVec(void) {
   trueD0.clear();    trueZ0.clear();  trueOmega.clear();   truePhi.clear();  trueTanLambda.clear();
   recoD0.clear();    recoZ0.clear();  recoOmega.clear();   recoPhi.clear();  recoTanLambda.clear();
   recoD0Error.clear();    recoZ0Error.clear();  recoOmegaError.clear();   recoPhiError.clear();  recoTanLambdaError.clear();
-  ghostPt.clear();  doubleCountingPt.clear();
-  foundTrkChi2OverNdof.clear();    ghostTrkChi2OverNdof.clear();  ghostCosTheta.clear(); doubleCountingCosTheta.clear();
+  foundTrkChi2OverNdof.clear();
   MarlinTrkHits.clear();   VXDHits.clear();  SITHits.clear();  FTDHits.clear();  TPCHits.clear();
-  BadTrksZ0.clear();  BadTrksD0.clear(); ghost_hits.clear();
-  ghostWgt.clear(); generatorStatus.clear(); DecayedInTracker.clear();
 
 }
 
@@ -466,8 +361,7 @@ void DDDiagnostics::initParameters(void) {
 
 DDDiagnostics::DDDiagnostics() : Processor("DDDiagnostics") {
 
-  // modify processor description
-  _description = "DDDiagnostics does whatever it does ..." ;
+  _description = "DDDiagnostics generates information for tracking performance monitor." ;
 
   initParameters() ;
 
@@ -478,16 +372,12 @@ void DDDiagnostics::init() {
 
   streamlog_out(DEBUG) << "   DDDiagnostics::init() called  "  << std::endl ;
 
-  // usually a good idea to
   printParameters() ;
   nEvt = 0;
 
   _bField = MarlinUtil::getBzAtOrigin();
 
-  ghostCounter = 0 ;
-
   gROOT->ProcessLine("#include <vector>");
-  //TApplication theApp("tapp", 0, 0);
 
   PI = (double)acos((double)(-1.0));
   TWOPI = (double)(2.0)*PI;
@@ -504,9 +394,9 @@ void DDDiagnostics::processEvent( LCEvent * evt ) {
   if( isFirstEvent() ) { 
     streamlog_out(DEBUG4) << " This is the first event " << std::endl;
 
-    if ( _fillBigTTree )  initTree() ;
-
     initHist() ;
+
+    if ( _fillBigTTree )  initTree() ;
   }
 
   clearVec() ;
@@ -514,7 +404,7 @@ void DDDiagnostics::processEvent( LCEvent * evt ) {
   typedef std::map< Track* , int> TrackMap;
   TrackMap MarlinTrkMap ;
 
-  int flagTrack = 0; int flagRecoToTrue = 0 ; int  flagTrueToReco = 0 ; //int flagSiRel = 0;
+  int flagTrack = 0; int flagRecoToTrue = 0 ; int  flagTrueToReco = 0 ;
   int  flagBCALPart = 0 ;     int  flagBCALCluster = 0 ;   int flagPFO = 0 ;
 
   const StringVec*  colNames = evt->getCollectionNames() ;
@@ -522,9 +412,6 @@ void DDDiagnostics::processEvent( LCEvent * evt ) {
 
     if  ( _trackColName == *it )
       flagTrack = 1 ;
-
-    //if  ( _vxdTrkHitRelations == *it )
-    //  flagSiRel = 1 ;
 
     if  ( _recoToTrue == *it )
       flagRecoToTrue = 1 ;
@@ -625,8 +512,6 @@ void DDDiagnostics::processEvent( LCEvent * evt ) {
 	    
 	    hitMapVXD[ mcp ] ++ ;
 	    
-	    //HitsInLayers[ layer ] ++ ;
-	    
 	    HitsInLayersPerMCP_VXD[mcp][layer] ++ ;
 	    
 	  }
@@ -723,9 +608,8 @@ void DDDiagnostics::processEvent( LCEvent * evt ) {
       
       if( cut ) {
 	mcpTracks.push_back( mcp ) ;
-      streamlog_out(DEBUG4) << " mcparticle that survives cuts " << mcp << std::endl;  
-      //streamlog_out(DEBUG4) << " mcparticle " << mcp << " VXD hits " << hitMapVXD[ mcp ] << " SIT hits " << hitMapSIT[ mcp ] << " TPC hits " << hitMapTPC[ mcp ] << std::endl ;
-      streamlog_out(DEBUG4) << " mcparticle " << mcp << " makes hits in " << noOfLayersPerMCP[ mcp ] << " VXD layers " << std::endl ;
+	streamlog_out(DEBUG4) << " mcparticle that survives cuts " << mcp << std::endl;
+	streamlog_out(DEBUG4) << " mcparticle " << mcp << " makes hits in " << noOfLayersPerMCP[ mcp ] << " VXD layers " << std::endl ;
       }
     }
     //_________________________________________________________________________________________________________________________________________________
@@ -862,7 +746,6 @@ void DDDiagnostics::processEvent( LCEvent * evt ) {
 	  double rec_z0_err = ((Track*)trkvec[jj])->getCovMatrix()[9] ;
 	  double rec_omega = ((Track*)trkvec[jj])->getOmega();
 	  double rec_omega_error = ((Track*)trkvec[jj])->getCovMatrix()[5];
-	  // double rec_phi = ((Track*)trkvec[jj])->getPhi();
 	  double rec_phi_error = ((Track*)trkvec[jj])->getCovMatrix()[2];
 	  double rec_tanlambda = ((Track*)trkvec[jj])->getTanLambda() ;
 	  double rec_tanlambda_err = ((Track*)trkvec[jj])->getCovMatrix()[14] ;
@@ -928,93 +811,12 @@ void DDDiagnostics::processEvent( LCEvent * evt ) {
       
       if (foundFlag==1) { streamlog_out(DEBUG4) << " Particle " << mcpTracks[ii] << " which makes " <<  hitMapVXD[ mcpTracks[ii] ] + hitMapSIT[ mcpTracks[ii] ] +  hitMapTPC[ mcpTracks[ii] ]<< " hits, found " << " and " <<  hitMapVXD[ mcpTracks[ii] ] << " VXD hits " << std::endl ; }
       if (foundFlag==0) { streamlog_out(DEBUG4) << " Particle " << mcpTracks[ii] << " which makes " <<  hitMapVXD[ mcpTracks[ii] ] + hitMapSIT[ mcpTracks[ii] ] +  hitMapTPC[ mcpTracks[ii] ]<< " hits " << " and " <<  hitMapVXD[ mcpTracks[ii] ] << " VXD hits and " <<  hitMapSIT[ mcpTracks[ii] ] << " SIT hits,  NOT found " << std::endl ; }
-      //if (foundFlag==0) { streamlog_out(DEBUG4) << " Particle " << mcpTracks[ii] << " which crosses " <<   noOfLayersPerMCP[ mcp ]  << " layers, NOT found " << std::endl ; }
       
     }  // end loop on tracks
-    
-    
-    for( TrackMap::iterator ii=MarlinTrkMap.begin(); ii!=MarlinTrkMap.end(); ++ii)
-      {
-	streamlog_out(DEBUG4) << " Found silicon tracks " << (*ii).first << ": " << (*ii).second << endl;
 
-	double ghost_Pt = fabs(((3.0/10000.0)*_bField) / ((*ii).first)->getOmega());
-	double ghost_phi = ((*ii).first)->getPhi() ;
-	double ghost_tanLam = ((*ii).first)->getTanLambda() ;
-	double px = ghost_Pt * cos( ghost_phi ) ;
-	double py = ghost_Pt * sin( ghost_phi ) ;
-	double pz = ghost_Pt * ghost_tanLam ;
-	double ghost_P = sqrt( px*px + py*py + pz*pz );
-	double ghost_Cos_Theta = cos ( atan ( (1.0 / ((*ii).first)->getTanLambda()))) ;
-	hist_pt_allMarTrk->Fill( ghost_Pt );
-	hist_p_allMarTrk->Fill( ghost_P );
-	hist_th_allMarTrk->Fill( fabs( ghost_Cos_Theta ) );
-	hist_thm_allMarTrk->Fill( ghost_Cos_Theta );
-
-	if ( (*ii).second == 1 ) {
-
-	  const EVENT::LCObjectVec& mcprelvec = nav.getRelatedFromObjects((*ii).first);
-	  //FloatVec ghWgt = navRtT.getRelatedToWeights( (*ii).first );
-	  //if(mcprelvec.size() != 1) continue;
-
-	  //double ghost_Cos_Theta = cos ( atan ( (1.0 / ((*ii).first)->getTanLambda()))) ;
-
-	  TrackerHitVec ghostTrkHits = ((*ii).first)->getTrackerHits();
-	  ghost_hits.push_back(ghostTrkHits.size());
-
-	  if (ghost_Cos_Theta <= _cosTheta ) {
-	    streamlog_out(DEBUG4) << " Adding to the ghost - bkg track list, track " <<  (*ii).first << " with momentum " << fabs(((3.0/10000.0)*_bField) / ((*ii).first)->getOmega()) << " & no of hits " <<  ghostTrkHits.size() << " being related to " << mcprelvec.size() << " MCParticles "  << std::endl ;
-	    
-	    ghostPt.push_back( ghost_Pt ) ;
-	    ghostCosTheta.push_back( ghost_Cos_Theta ) ;
-
-	    hist_pt_fakeMarTrk->Fill( ghost_Pt );
-	    hist_p_fakeMarTrk->Fill( ghost_P );
-	    hist_th_fakeMarTrk->Fill( fabs( ghost_Cos_Theta ) );
-	    hist_thm_fakeMarTrk->Fill( ghost_Cos_Theta );
-
-	    double ghostTrkChi2 = ((*ii).first)->getChi2();
-	    double ghostTrkNdf = ((*ii).first)->getNdf();
-	    BadTrksD0.push_back(((*ii).first)->getD0());
-	    BadTrksZ0.push_back(((*ii).first)->getZ0());
-
-	    for(unsigned int ghid=0; ghid < mcprelvec.size(); ghid++ ) {
-	      FloatVec ghWgt = nav.getRelatedToWeights( mcprelvec[ghid] );
-	      generatorStatus.push_back(  ((MCParticle*)mcprelvec[ghid])->getGeneratorStatus() );
-	      DecayedInTracker.push_back(  ((MCParticle*)mcprelvec[ghid])->isDecayedInTracker() );
-	      ghostWgt.push_back( ghWgt[ghid] );
-	    }
-	    
-	    /*
-	    for(int ghid=0; ghid <ghWgt.size(); ghid++ ) {
-	      ghostWgt.push_back( ghWgt[ghid] );
-	    }
-	    */
-	    if ( ghostTrkNdf != 0 ) { ghostTrkChi2OverNdof.push_back( ghostTrkChi2/ghostTrkNdf ) ; }
-	    
-	    ghostCounter++ ;
-	    
-	  }
-        }
-	else if( (*ii).second > 2 ) {
-
-	  //const EVENT::LCObjectVec& mcprelvec = nav.getRelatedFromObjects((*ii).first);
-
-	  double doubleCounting_Cos_Theta = cos ( atan ( (1.0 / ((*ii).first)->getTanLambda()))) ;
-	  if (doubleCounting_Cos_Theta <= _cosTheta ) {
-	    streamlog_out(DEBUG4) << " Adding to the doubleCounting track list, track " <<  (*ii).first << " with momentum " << fabs(((3.0/10000.0)*_bField) / ((*ii).first)->getOmega())  << std::endl ;
-
-	    doubleCountingPt.push_back( fabs(((3.0/10000.0)*_bField) / ((*ii).first)->getOmega())) ;
-	    doubleCountingCosTheta.push_back( doubleCounting_Cos_Theta ) ;
-	  }
-	}
-      }
-    
   }  // condition for the existence of the relation collections
   
-  if ( _fillBigTTree ) {
-    EvalTree->Fill();
-    GhostTree->Fill();
-  }
+  if ( _fillBigTTree )  EvalTree->Fill();
 
   nEvt++;
   

--- a/tracking/src/DDDiagnostics.cc
+++ b/tracking/src/DDDiagnostics.cc
@@ -265,8 +265,8 @@ void DDDiagnostics::initParameters(void) {
   registerInputCollection( LCIO::TRACKERHIT,
 			   "SpcPntsCollection" ,
 			   "Name of the SIT SpacePoints collection"  ,
-			   _sitSpacePoints ,
-			   std::string("SITSpacePoints")  ) ;
+			   _sitTrackerHits ,
+			   std::string("SITTrackerHits")  ) ;
 
   registerInputCollection( LCIO::TRACKERHIT,
 			   "VXDTrackerHits" ,

--- a/tracking/src/DDDiagnostics.cc
+++ b/tracking/src/DDDiagnostics.cc
@@ -32,12 +32,8 @@ void DDDiagnostics::initTree(void) {
 
   EvalTree = new TTree("EvalTree","EvalTree");
   EvalTree->Branch("foundTrk",&foundTrk) ;
-  EvalTree->Branch("BCalParts",&BCalParts,"BCalParts/I") ;
-  EvalTree->Branch("BCalCls",&BCalCls,"BCalCls/I") ;
-  EvalTree->Branch("pfos",&pfos,"pfos/I") ;
   EvalTree->Branch("PtReco",&PtReco) ;
   EvalTree->Branch("CosThetaReco",&CosThetaReco) ;
-  EvalTree->Branch("SiTrksPt",&SiTrksPt) ;
   EvalTree->Branch("foundTrkChi2OverNdof",&foundTrkChi2OverNdof);
   EvalTree->Branch("PtMCP",&PtMCP) ;
   EvalTree->Branch("CosThetaMCP",&CosThetaMCP) ;
@@ -48,13 +44,12 @@ void DDDiagnostics::initTree(void) {
   EvalTree->Branch("SITHits",&SITHits) ;
   EvalTree->Branch("FTDHits",&FTDHits) ;
   EvalTree->Branch("TPCHits",&TPCHits) ;
-  EvalTree->Branch("MarlinTracks",&MarlinTracks,"MarlinTracks/I") ;
   EvalTree->Branch("trueD0",&trueD0) ;
   EvalTree->Branch("trueZ0",&trueZ0) ;
   EvalTree->Branch("recoD0",&recoD0) ;
   EvalTree->Branch("recoZ0",&recoZ0) ;
-  EvalTree->Branch("recoD0error",&recoD0error) ;
-  EvalTree->Branch("recoZ0error",&recoZ0error) ;
+  EvalTree->Branch("recoD0Error",&recoD0Error) ;
+  EvalTree->Branch("recoZ0Error",&recoZ0Error) ;
   EvalTree->Branch("trueOmega",&trueOmega) ;
   EvalTree->Branch("truePhi",&truePhi) ;
   EvalTree->Branch("trueTanLambda",&trueTanLambda) ;
@@ -254,23 +249,6 @@ void DDDiagnostics::initParameters(void) {
 			   _mcParticleCollectionName ,
 			   std::string("MCParticle") ) ;
 
-  registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-			   "BCALParticles" , 
-			   "Name of the BCALParticles input collection"  ,
-			   _BCALParticleCollectionName ,
-			   std::string("BCALParticles") ) ;
-
-  registerInputCollection( LCIO::CLUSTER,
-			   "BCALCLusters" , 
-			   "Name of the BCAL clusters input collection"  ,
-			   _BCALClusterCollectionName ,
-			   std::string("BCALCLusters") ) ;
-
-  registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-                            "PFOs" , 
-                            "particle flow objects"  ,
-                            _pandoraPFOs ,
-                            std::string("PandoraPFOs") ) ;
 
   StringVec exampleSimHits ;
   exampleSimHits.push_back("VXDCollection") ;
@@ -405,7 +383,6 @@ void DDDiagnostics::processEvent( LCEvent * evt ) {
   TrackMap MarlinTrkMap ;
 
   int flagTrack = 0; int flagRecoToTrue = 0 ; int  flagTrueToReco = 0 ;
-  int  flagBCALPart = 0 ;     int  flagBCALCluster = 0 ;   int flagPFO = 0 ;
 
   const StringVec*  colNames = evt->getCollectionNames() ;
   for( StringVec::const_iterator it = colNames->begin() ; it != colNames->end() ; it++ ){
@@ -418,15 +395,6 @@ void DDDiagnostics::processEvent( LCEvent * evt ) {
 
     if  ( _trueToReco == *it )
       flagTrueToReco = 1 ;
-
-    if (  _BCALParticleCollectionName == *it )
-      flagBCALPart = 1 ;
-
-    if (  _BCALClusterCollectionName == *it )
-      flagBCALCluster = 1 ;
-
-    if ( _pandoraPFOs  == *it )
-      flagPFO = 1 ;
 
   }
 
@@ -447,21 +415,6 @@ void DDDiagnostics::processEvent( LCEvent * evt ) {
     }
   }
 
-
-  if (flagBCALPart == 1 ){
-    LCCollection* BCalParty = evt->getCollection( _BCALParticleCollectionName );
-    BCalParts = BCalParty->getNumberOfElements();
-  }
-
-  if (flagBCALCluster == 1 ){
-    LCCollection* BCalClassy = evt->getCollection( _BCALParticleCollectionName );
-    BCalCls = BCalClassy->getNumberOfElements();
-  }
-  
-  if (flagPFO == 1 ){
-    LCCollection* Particles = evt->getCollection( _pandoraPFOs );
-    pfos = Particles->getNumberOfElements();
-  }
   
 
   if ( flagRecoToTrue == 1 && flagTrueToReco == 1 ){   // condition for the existence of the relation collections
@@ -759,9 +712,9 @@ void DDDiagnostics::processEvent( LCEvent * evt ) {
 	  truePhi.push_back(phmcp);
 	  trueTanLambda.push_back(tLmcp);
 	  recoD0.push_back(((Track*)trkvec[jj])->getD0());
-	  recoD0error.push_back(((Track*)trkvec[jj])->getCovMatrix()[0]);
+	  recoD0Error.push_back(((Track*)trkvec[jj])->getCovMatrix()[0]);
 	  recoZ0.push_back(((Track*)trkvec[jj])->getZ0());
-	  recoZ0error.push_back(((Track*)trkvec[jj])->getCovMatrix()[9]);
+	  recoZ0Error.push_back(((Track*)trkvec[jj])->getCovMatrix()[9]);
 	  recoOmega.push_back(((Track*)trkvec[jj])->getOmega());
 	  recoOmegaError.push_back(((Track*)trkvec[jj])->getCovMatrix()[5]);
 

--- a/tracking/test/DDDiagnostics.xml
+++ b/tracking/test/DDDiagnostics.xml
@@ -13,7 +13,6 @@
   <execute>
     <processor name="MyAIDAProcessor"/>
     <processor name="InitDD4hep"/>
-    <!--processor name="MyRecoMCTruthLinker"/-->
     <processor name="MyDiagnostics"/>
   </execute>
 
@@ -44,106 +43,6 @@
     <!--Name of the DD4hep compact xml file to load-->
     <parameter name="DD4hepXMLFile" type="string"> $lcgeo_DIR/ILD/compact/ILD_l5_v02/ILD_l5_v02.xml </parameter>
   </processor>
-
-  <processor name="MyRecoMCTruthLinker" type="RecoMCTruthLinker">
-    <!--links RecontructedParticles to the MCParticle based on number of hits used-->
-   
-    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-    <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT"> WARNING0  </parameter>
-   
-    <!--  Input collections: mcparticles, pfos, clusters and tracks
-          PFOs already connect to tracks and clusters, so what we do in this processor is to connect
-          tracks and clusters to mcparticles ...
-          The values given here are the defaults, so they don't really need to be
-          specified -->
-    <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle"> MCParticle </parameter>
-    <!--Name of the ReconstructedParticles input collection-->
-    <parameter name="RecoParticleCollection" type="string" lcioInType="ReconstructedParticle"> PandoraPFOs </parameter>
-    <!--Name of the Cluster collection -->
-    <parameter name="ClusterCollection" type="string" lcioInType="Cluster"> PandoraClusters </parameter>
-    <!--Name of the Tracks input collection-->
-    <parameter name="TrackCollection" type="string" lcioInType="Track">MarlinTrkTracks </parameter>
- 
-    <!-- Don't change any of these hit related collections if you're not very sure you know what you are doing.
-	 In any case, the ones listed here are the defaults, so they can be removed from
-	 this steering -->
-    <!--  Simulated tracker hits (has the conection to MCParticles -->
-    <parameter name="SimTrackerHitCollections" type="StringVec" lcioInType="SimTrackerHit">
-      VXDCollection
-      SITCollection
-      FTD_PIXELCollection
-      FTD_STRIPCollection
-      TPCCollection
-      SETCollection
-    </parameter>
-    <!--  Connections from tracker hits (connected to tracks) to sim tracker hits (connects to MC particle) -->
-    <parameter name="TrackerHitsRelInputCollections" type="StringVec" lcioInType="LCRelation">
-      VXDTrackerHitRelations
-      SITSpacePointRelations
-      FTDPixelTrackerHitRelations
-      FTDSpacePointRelations
-      TPCTrackerHitRelations
-      SETSpacePointRelations
-    </parameter>
-    <!-- same for the calos: Simulated calo hits (has the connection to MCParticles) -->
-    <parameter name="SimCaloHitCollections" type="StringVec" lcioInType="SimCalorimeterHit">
-      BeamCalCollection
-      EcalBarrelSiliconCollection
-      EcalBarrelSiliconPreShowerCollection
-      EcalEndcapRingCollection
-      EcalEndcapRingPreShowerCollection
-      EcalEndcapSiliconCollection
-      EcalEndcapSiliconPreShowerCollection
-      HcalBarrelRegCollection
-      HcalEndCapRingsCollection
-      HcalEndCapsCollection
-      LHcalCollection
-      LumiCalCollection
-      MuonBarrelCollection
-      MuonEndCapCollection
-    </parameter>
-    <!-- Connections from calo hist (connected to clusters) tp sim calo hits  (connects to MC particle) -->
-    <parameter name="SimCalorimeterHitRelationNames" type="StringVec" lcioInType="LCRelation">
-      RelationCaloHit
-      RelationLHcalHit
-      RelationMuonHit
-      RelationLcalHit
-      RelationBCalHit
-    </parameter>
-
-    <!--PDG codes of particles of which the daughters will be kept in the skimmmed MCParticle collection-->
-    <parameter name="KeepDaughtersPDG" type="IntVec"> 22 111 310 13 211 321</parameter>
-
-    <!--Names of the output collections -->
-    <!--Name of the skimmed MCParticle  output collection-->
-    <parameter name="MCParticlesSkimmedName" type="string" lcioOutType="MCParticle"> MCParticlesSkimmed </parameter>
-
-    <!-- links between tracks or clusters and mcparticles. The two sets differ
-	 in what the weight means. These four will only be output if the
-	 name is given here in the steering -->
-    <parameter name="MCTruthTrackLinkName" type="string" lcioOutType="LCRelation"> MCTruthMarlinTrkTracksLink </parameter>
-    <parameter name="TrackMCTruthLinkName" type="string" lcioOutType="LCRelation"> MarlinTrkTracksMCTruthLink </parameter>
-    <parameter name="MCTruthClusterLinkName" type="string" lcioOutType="LCRelation"> MCTruthClusterLink </parameter>
-    <parameter name="ClusterMCTruthLinkName" type="string" lcioOutType="LCRelation"> ClusterMCTruthLink </parameter>
-
-
-    <!-- Links PFO <-> MCParticles. Only RecoMCTruthLink is output by default,
-	 to also get the reverse link, MCTruthRecoLinkName must be given here -->
-    <parameter name="RecoMCTruthLinkName" type="string" lcioOutType="LCRelation"> RecoMCTruthLink </parameter>
-    <parameter name="MCTruthRecoLinkName" type="string" lcioOutType="LCRelation"> MCTruthRecoLink </parameter>
-    <!-- set to true to get the weights in RecoMCTruthLink to include both weights to
-	 tracks and clusters. False implies that only the true particle that
-	 gives most contributions to the track of the PFO (charged PFOs), or
-	 to the cluster (neutral ones) is linked to the PFO -->
-    <parameter name="FullRecoRelation" type="bool"> true </parameter>
-
-    <!-- further options -->
-    <!--true: use relations for TrackerHits, false : use getRawHits -->
-    <parameter name="UseTrackerHitRelations" type="bool"> true </parameter>
-    <!--If Using Particle Gun Ignore Gen Stat-->
-    <parameter name="UsingParticleGun" type="bool"> true </parameter>
-  </processor>
-
 
   <processor name="MyDiagnostics" type="DDDiagnostics">
     <!--Fill the more detail information into TTree for DEBUG.-->

--- a/tracking/test/DDDiagnostics.xml
+++ b/tracking/test/DDDiagnostics.xml
@@ -75,7 +75,7 @@
     <parameter name="RequiredSiHits" type="int"> 4 </parameter>
     <!--Requirement that the innermost VXD hit should be found-->
     <parameter name="ReqInnVXDHit" type="bool"> false </parameter>
-    <parameter name="SimTrackerHitCollections" type="StringVec" lcioInType="SimTrackerHit"> VXDCollection SITCollection TPCCollection </parameter>
+    <parameter name="SimTrackerHitCollections" type="StringVec" lcioInType="SimTrackerHit"> VXDCollection FTDCollection SITCollection TPCCollection </parameter>
     <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
     <parameter name="Verbosity" type="string"> MESSAGE </parameter>
   </processor>

--- a/tracking/test/Diagnostics_ILD_l5_v02_ttbar.xml
+++ b/tracking/test/Diagnostics_ILD_l5_v02_ttbar.xml
@@ -194,7 +194,7 @@
     <parameter name="RequiredSiHits" type="int"> 4 </parameter>
     <!--Requirement that the innermost VXD hit should be found-->
     <parameter name="ReqInnVXDHit" type="bool"> false </parameter>
-    <parameter name="SimTrackerHitCollections" type="StringVec" lcioInType="SimTrackerHit"> VXDCollection SITCollection TPCCollection </parameter>
+    <parameter name="SimTrackerHitCollections" type="StringVec" lcioInType="SimTrackerHit"> VXDCollection FTDCollection SITCollection TPCCollection </parameter>
     <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
     <parameter name="Verbosity" type="string"> MESSAGE </parameter>
   </processor>

--- a/tracking/test/htc_job_singleMuon.sub
+++ b/tracking/test/htc_job_singleMuon.sub
@@ -38,7 +38,7 @@ InitialDir = $ENV(PWD)
 Notification = Always
 #
 # Defaults to 1 day:
-#+RequestRuntime = 3600 * 3
++RequestRuntime = 3600 * 12
 #
 # Defaults to 3G
 #RequestDisk = 2048 * 3

--- a/tracking/test/htc_job_ttbar.sub
+++ b/tracking/test/htc_job_ttbar.sub
@@ -38,7 +38,7 @@ InitialDir = $ENV(PWD)
 Notification = Always
 #
 # Defaults to 1 day:
-#+RequestRuntime = 3600 * 3
++RequestRuntime = 3600 * 12
 #
 # Defaults to 3G
 #RequestDisk = 2048 * 3

--- a/tracking/test/lcio_particle_gun.py
+++ b/tracking/test/lcio_particle_gun.py
@@ -18,7 +18,7 @@ from array import array
 from pyLCIO import UTIL, EVENT, IMPL, IO, IOIMPL
 
 #---- number of events per momentum bin -----
-nevt = 1000
+nevt = 5000
 
 #outfile = "mcparticles.slcio"
 

--- a/tracking/test/run_ILD_l5_v02_singleMuon.sh
+++ b/tracking/test/run_ILD_l5_v02_singleMuon.sh
@@ -4,52 +4,6 @@
 # Running shell script in parallel over multiple cores
 #==============================================================
 
-echo "############################################################################"
-echo "                             System information"
-echo "                             =================="
-
-echo "Host:"
-hostname -f
-
-echo "CPU(s):"
-cat /proc/cpuinfo | grep "model name" | cut -b 14-
-
-echo "RAM:"
-cat /proc/meminfo | grep "MemTotal" | cut -b 10-
-
-echo "Swap:"
-cat /proc/meminfo | grep "SwapTotal" | cut -b 11-
-
-echo "############################################################################"
-echo "Group:      ${GROUP}"
-
-echo "Hosttype:   ${HOSTTYPE}"
-
-echo "JobID:      ${JOB_ID}"
-
-echo "JobName:    ${JOB_NAME}"
-
-echo "Job_Script: ${JOB_SCRIPT}"
-
-echo "User:       ${LOGNAME}"
-
-echo "Queue:      ${QUEUE}"
-
-echo "Shell:      ${SHELL}"
-
-echo "TMP:        ${TMP}"
-
-echo "TMPDIR:     ${TMPDIR}"
-
-echo "User:       ${USER}"
-
-echo "Working_DIR:${PWD}"
-
-echo "############################################################################"
-echo
-echo "############################################################################"
-echo
-
 ILDMODEL=ILD_l5_v02
 ILCSOFTVER=v01-19-05
 
@@ -90,8 +44,8 @@ ddsim \
     --inputFiles Results/GenFiles/mcparticles_MuonsAngle_${PolarAngles[i]}_Mom_${Mom[j]}.slcio  \
     --outputFile ${ILDMODEL}_${ILCSOFTVER}_MuonsAngle_${PolarAngles[i]}_Mom_${Mom[j]}_SIM.slcio \
     --compactFile $lcgeo_DIR/ILD/compact/${ILDMODEL}/${ILDMODEL}.xml \
-    --steeringFile ddsim_steer.py \
-    --numberOfEvents 1000 &
+    --steeringFile ddsim_steer.py
+
 done
 wait
 done
@@ -146,6 +100,7 @@ INFILE=Results/RecoFiles/${ILDMODEL}_${ILCSOFTVER}_MuonsAngle_${PolarAngles[i]}_
 
 Marlin DDDiagnostics.xml \
     --global.LCIOInputFiles=$INFILE \
+    --InitDD4hep.DD4hepXMLFile=$lcgeo_DIR/ILD/compact/ILD_l5_v02/ILD_l5_v02.xml \
     --MyAIDAProcessor.FileName=analysis_${ILDMODEL}_${ILCSOFTVER}_MuonsAngle_${PolarAngles[i]}_Mom_${Mom[j]} \
     --MyDiagnostics.FillBigTTree=true \
     --MyDiagnostics.PhysSampleOn=false \
@@ -179,11 +134,12 @@ root -b -q PResolutionL5.C
 root -b -q meanL5.C
 root -b -q sigmaL5.C
 
-mkdir -p ~/www/ILDPerformance_${ILCSOFTVER}
+OUTPUTPATH=~/www/ILDPerformance_${ILCSOFTVER}
+mkdir -p ${OUTPUTPATH}
 
-cp IPResolution_${ILDMODEL}_${ILCSOFTVER}.png ~/www/ILDPerformance_${ILCSOFTVER}
-cp D0_fit_${ILDMODEL}_${ILCSOFTVER}.pdf ~/www/ILDPerformance_${ILCSOFTVER}
-cp PResolution_${ILDMODEL}_${ILCSOFTVER}.png ~/www/ILDPerformance_${ILCSOFTVER}
-cp PR_fit_${ILDMODEL}_${ILCSOFTVER}.pdf ~/www/ILDPerformance_${ILCSOFTVER}
-cp pull_mean_${ILDMODEL}_${ILCSOFTVER}.png ~/www/ILDPerformance_${ILCSOFTVER}
-cp pull_sigma_${ILDMODEL}_${ILCSOFTVER}.png ~/www/ILDPerformance_${ILCSOFTVER}
+cp IPResolution_${ILDMODEL}_${ILCSOFTVER}.png ${OUTPUTPATH}
+cp D0_fit_${ILDMODEL}_${ILCSOFTVER}.pdf ${OUTPUTPATH}
+cp PResolution_${ILDMODEL}_${ILCSOFTVER}.png ${OUTPUTPATH}
+cp PR_fit_${ILDMODEL}_${ILCSOFTVER}.pdf ${OUTPUTPATH}
+cp pull_mean_${ILDMODEL}_${ILCSOFTVER}.png ${OUTPUTPATH}
+cp pull_sigma_${ILDMODEL}_${ILCSOFTVER}.png ${OUTPUTPATH}

--- a/tracking/test/run_ILD_l5_v02_ttbar.sh
+++ b/tracking/test/run_ILD_l5_v02_ttbar.sh
@@ -4,59 +4,11 @@
 # Running shell script in parallel over multiple cores
 #==============================================================
 
-echo "############################################################################"
-echo "                             System information"
-echo "                             =================="
-
-echo "Host:"
-hostname -f
-
-echo "CPU(s):"
-cat /proc/cpuinfo | grep "model name" | cut -b 14-
-
-echo "RAM:"
-cat /proc/meminfo | grep "MemTotal" | cut -b 10-
-
-echo "Swap:"
-cat /proc/meminfo | grep "SwapTotal" | cut -b 11-
-
-echo "############################################################################"
-echo "Group:      ${GROUP}"
-
-echo "Hosttype:   ${HOSTTYPE}"
-
-echo "JobID:      ${JOB_ID}"
-
-echo "JobName:    ${JOB_NAME}"
-
-echo "Job_Script: ${JOB_SCRIPT}"
-
-echo "User:       ${LOGNAME}"
-
-echo "Queue:      ${QUEUE}"
-
-echo "Shell:      ${SHELL}"
-
-echo "TMP:        ${TMP}"
-
-echo "TMPDIR:     ${TMPDIR}"
-
-echo "User:       ${USER}"
-
-echo "Working_DIR:${PWD}"
-
-echo "############################################################################"
-echo
-echo "############################################################################"
-echo
-
 ILDMODEL=ILD_l5_v02
 ILCSOFTVER=v01-19-05
 
 . /afs/desy.de/project/ilcsoft/sw/x86_64_gcc49_sl6/${ILCSOFTVER}/init_ilcsoft.sh
 
-#INFILE=/nfs/dust/ilc/user/voutsina/GenFiles/E250-TDR_ws.Pe2e2h_mumu.Gwhizard-1_95.eL.pR.I108009.001.stdhep
-#INFILE=/nfs/dust/ilc/group/ild/dbd-data/250/higgs/E250-TDR_ws.Pe2e2h_mumu.Gwhizard-1_95.eL.pR.I108009.001.stdhep
 INFILE=/nfs/dust/ilc/group/ild/dbd-data/500/6f/E0500-TDR_ws.Pyycyyc.Gwhizard-1.95.eR.pL.I36919.05.stdhep
 
 #==================================================
@@ -110,6 +62,7 @@ rm ${ILDMODEL}_${ILCSOFTVER}_E0500-TDR_ws.Pyycyyc.Gwhizard-1.95.eR.pL.I36919.05_
 # diagnostics
 
 Marlin Diagnostics_ILD_l5_v02_ttbar.xml \
+    --constant.lcgeo_DIR=$lcgeo_DIR \
     --MyAIDAProcessor.FileName=analysis_${ILDMODEL}_${ILCSOFTVER}_E0500-TDR_ws.Pyycyyc.Gwhizard-1.95.eR.pL.I36919.05 \
     --MyDiagnostics.PhysSampleOn=true \
 > DIAG_${ILDMODEL}_${ILCSOFTVER}_E0500-TDR_ws.Pyycyyc.Gwhizard-1.95.eR.pL.I36919.05.out
@@ -133,7 +86,8 @@ mv  analysis_${ILDMODEL}_${ILCSOFTVER}_E0500-TDR_ws.Pyycyyc.Gwhizard-1.95.eR.pL.
 cd ../macros
 root -b -q EfficiencyL5.C
 
-mkdir -p ~/www/ILDPerformance_${ILCSOFTVER}
+OUTPUTPATH=~/www/ILDPerformance_${ILCSOFTVER}
+mkdir -p ${OUTPUTPATH}
 
-cp trkEff_pt_ttbar_${ILDMODEL}_${ILCSOFTVER}.png ~/www/ILDPerformance_${ILCSOFTVER}
-cp trkEff_theta_ttbar_${ILDMODEL}_${ILCSOFTVER}.png ~/www/ILDPerformance_${ILCSOFTVER}
+cp trkEff_pt_ttbar_${ILDMODEL}_${ILCSOFTVER}.png ${OUTPUTPATH}
+cp trkEff_theta_ttbar_${ILDMODEL}_${ILCSOFTVER}.png ${OUTPUTPATH}


### PR DESCRIPTION
BEGINRELEASENOTES
- cleanup the massive monitoring information of tracking. 
- cleanup the job scripts which are used on DESY NAF2 working nodes.
- increase the statistic to 5000 single muons for each check point.
- added RequestRuntime for expected longer runtime on DESY NAF2 working nodes
- added FTDCollection, and count the true hits number in FTD simulation too.
- adapt to pixel SIT, and change the name from SITSpacePoints to SITTrackerHits.
- active minimum silicon hits number cut for MCParticles nominators.
    - count the silicon hits number from all VXD, SIT and FTD for each mcp track.

ENDRELEASENOTES