### PR TITLE
 use the same bins as DBD for tracking efficiency plots, and set RunBeamCalReco=false.

### DIFF
--- a/tracking/src/DDDiagnostics.cc
+++ b/tracking/src/DDDiagnostics.cc
@@ -84,11 +84,11 @@ void DDDiagnostics::initHist(void) {
   hist_pt_t  = new TH1F( "hist_pt_t", "Pt distributions of true tracks", nBins , bins ) ;
   hist_pt_f  = new TH1F( "hist_pt_f", "Pt distribution of found tracks", nBins , bins ) ;
 
-  hist_p_t  = new TH1F( "hist_p_t", "Momentum distributions of true tracks", 100 , 0.5, 100.5 ) ;
-  hist_p_f  = new TH1F( "hist_p_f", "Momentum distribution of found tracks", 100 , 0.5, 100.5 ) ;
+  hist_p_t  = new TH1F( "hist_p_t", "Momentum distributions of true tracks",  nBins , bins ) ;
+  hist_p_f  = new TH1F( "hist_p_f", "Momentum distribution of found tracks",  nBins , bins ) ;
 
-  hist_th_t  = new TH1F( "hist_th_t", "Cos theta distributions of true tracks", 10, 0., 1. ) ;
-  hist_th_f  = new TH1F( "hist_th_f", "Cos theta distribution of found tracks", 10, 0., 1. ) ;
+  hist_th_t  = new TH1F( "hist_th_t", "Cos theta distributions of true tracks", 20, 0., 1. ) ;
+  hist_th_f  = new TH1F( "hist_th_f", "Cos theta distribution of found tracks", 20, 0., 1. ) ;
 
   hist_thm_t  = new TH1F( "hist_thm_t", "Cos theta distributions of true tracks", 21, -1., 1. ) ;
   hist_thm_f  = new TH1F( "hist_thm_f", "Cos theta distribution of found tracks", 21, -1., 1. ) ;

--- a/tracking/test/run_ILD_l5_v02_singleMuon.sh
+++ b/tracking/test/run_ILD_l5_v02_singleMuon.sh
@@ -5,7 +5,7 @@
 #==============================================================
 
 ILDMODEL=ILD_l5_v02
-ILCSOFTVER=v01-19-05
+ILCSOFTVER=v01-19-06
 
 . /afs/desy.de/project/ilcsoft/sw/x86_64_gcc49_sl6/${ILCSOFTVER}/init_ilcsoft.sh
 
@@ -66,6 +66,7 @@ do
 Marlin MarlinStdReco.xml \
     --constant..DetectorModel=ILD_l5_o1_v02 \
     --global.LCIOInputFiles=Results/SimFiles/${ILDMODEL}_${ILCSOFTVER}_MuonsAngle_${PolarAngles[i]}_Mom_${Mom[j]}_SIM.slcio \
+    --constant.RunBeamCalReco=false \
     --constant.lcgeo_DIR=$lcgeo_DIR \
     --constant.OutputBaseName=${ILDMODEL}_${ILCSOFTVER}_MuonsAngle_${PolarAngles[i]}_Mom_${Mom[j]} \
     --MyRecoMCTruthLinker.UsingParticleGun=true \

--- a/tracking/test/run_ILD_l5_v02_ttbar.sh
+++ b/tracking/test/run_ILD_l5_v02_ttbar.sh
@@ -5,7 +5,7 @@
 #==============================================================
 
 ILDMODEL=ILD_l5_v02
-ILCSOFTVER=v01-19-05
+ILCSOFTVER=v01-19-06
 
 . /afs/desy.de/project/ilcsoft/sw/x86_64_gcc49_sl6/${ILCSOFTVER}/init_ilcsoft.sh
 
@@ -41,6 +41,7 @@ do
 Marlin MarlinStdReco.xml \
     --constant..DetectorModel=ILD_l5_o1_v02 \
     --global.LCIOInputFiles=Results/SimFiles/${ILDMODEL}_${ILCSOFTVER}_E0500-TDR_ws.Pyycyyc.Gwhizard-1.95.eR.pL.I36919.05_${i}_SIM.slcio \
+    --constant.RunBeamCalReco=false \
     --constant.lcgeo_DIR=$lcgeo_DIR \
     --constant.OutputBaseName=${ILDMODEL}_${ILCSOFTVER}_E0500-TDR_ws.Pyycyyc.Gwhizard-1.95.eR.pL.I36919.05_${i} \
     --MyRecoMCTruthLinker.UsingParticleGun=false \


### PR DESCRIPTION

BEGINRELEASENOTES
- update to the same bins as DBD for tracking efficiency plots.
- set RunBeamCalReco=false.
- update to next release ILCsoft v01-19-06.

ENDRELEASENOTES