### PR TITLE
Adding Time-Of-Flight scripts

### DIFF
--- a/TimeOfFlight/Readme.md
+++ b/TimeOfFlight/Readme.md
@@ -19,6 +19,7 @@ Currently only the Closest Hits TOF-approach is taken into account.
 
 The configuration files can be found in ```./config```.
 - `ParticleTypes.cnf` : Set the single particle types that should be investigated.
+- `PlottingSettings.cnf` : Set the binning for the beta-momentum plots (May be relevant for whether Gaussian fits succeed).
 - `Setup.cnf` : Set the environmental parameters for the setup that should be run (e.g. versions used in slcio file production, detector model).
 - `TimeResolutions.cnf` : Set the time resolutions that should be investigated. Only resolutions available in the REC files can be used.
 
@@ -48,3 +49,4 @@ Not yet implemented, only plotting macro and Config included.
   In the scripts the exact version that is used is hardcoded.
 - The REC files provided to the scripts must already contain the TOF information for each particle.
 - The REC files must follow the ILD file naming conventions.
+- Not all possible possibilities are tested (e.g. different TOF methods, ttbar) as of now.

--- a/TimeOfFlight/Readme.md
+++ b/TimeOfFlight/Readme.md
@@ -8,15 +8,43 @@ J. Beyer
 
 ## Running Time Of Flight separation: Step-by-step
 
-For either:
-```shell
-module load python3
-```
-
-<!-- TODO Write down that only resolutions which were simulated can be used here, otherwise rerun TOF processor! -->
+The scripts provided run on REC (`.slcio`) files, create LCTuple root files and run root macros to investigate the separation power.
+Currently only the Closest Hits TOF-approach is taken into account.
 
 ### Single particle events
-<!-- TODO Write where config files are and how to set them -->
-<!-- TODO Implement combined script that runs everything -->
+
+**0. Source iLCSoft**
+
+**1. Setting the configuration**
+
+The configuration files can be found in ```./config```.
+- `ParticleTypes.cnf` : Set the single particle types that should be investigated.
+- `Setup.cnf` : Set the environmental parameters for the setup that should be run (e.g. versions used in slcio file production, detector model).
+- `TimeResolutions.cnf` : Set the time resolutions that should be investigated. Only resolutions available in the REC files can be used.
+
+The `Setup.cnf` can be changed by simply manipulating the entries.
+To add other particle types or resolutions copy-paste and manipulate an entry in `ParticleTypes.cnf` or `TimeResolutions.cnf`, respectively.
+
+**2. Running the Marlin and plotting**
+
+All steps necessary to get the separation power plots are summarized in one script. This must first be made executable:
+```bash
+chmod u+x macros/run_singleparticle.sh
+```
+and can then be run like:
+```bash
+./macros/run_singleparticle.sh
+```
+
+The plots (and the LCTuple root files) can then be found in the appropriate directory in the `output` directory.
 
 ### ttbar events
+
+Not yet implemented, only plotting macro and Config included.
+
+### Comments
+
+- The scripts that read the configuration (`run_singleparticle_lctuple.sh` and `run_singleparticle_plotting.sh`) require Python3. 
+  In the scripts the exact version that is used is hardcoded.
+- The REC files provided to the scripts must already contain the TOF information for each particle.
+- The REC files must follow the ILD file naming conventions.

--- a/TimeOfFlight/Readme.md
+++ b/TimeOfFlight/Readme.md
@@ -1,0 +1,22 @@
+# ILDPerformance/TimeOfFlight
+
+Time Of Flight (TOF) for particle separation
+
+S. Dharani,
+F. Gaede, 
+J. Beyer
+
+## Running Time Of Flight separation: Step-by-step
+
+For either:
+```shell
+module load python3
+```
+
+<!-- TODO Write down that only resolutions which were simulated can be used here, otherwise rerun TOF processor! -->
+
+### Single particle events
+<!-- TODO Write where config files are and how to set them -->
+<!-- TODO Implement combined script that runs everything -->
+
+### ttbar events

--- a/TimeOfFlight/config/ParticleTypes.cnf
+++ b/TimeOfFlight/config/ParticleTypes.cnf
@@ -1,0 +1,29 @@
+[Proton]
+name_s = p
+pdgID  = 2212
+mass   = 0.938272
+colour = 633
+
+[Kaon]
+name_s = K
+pdgID  = 321
+mass   = 0.493677
+colour = 418
+
+[Pion]
+name_s = Pi
+pdgID  = 211
+mass   = 0.13957
+colour = 880
+
+[Electron]
+name_s = e1
+pdgID  = 11
+mass   = 0.000511
+colour = 433
+
+[Muon]
+name_s = e2
+pdgID  = 13
+mass   = 0.1056584
+colour = 597

--- a/TimeOfFlight/config/PlottingSettings.cnf
+++ b/TimeOfFlight/config/PlottingSettings.cnf
@@ -1,0 +1,4 @@
+[BetaPPlots]
+NbinsBeta = 2000
+NbinsP    = 500
+BinJumpsPerSlice = 10

--- a/TimeOfFlight/config/Setup.cnf
+++ b/TimeOfFlight/config/Setup.cnf
@@ -4,7 +4,7 @@ ILDConfigVersion = 02-00-01
 OutputBase       = output
 
 [Experiment]
-DetectorModel = l5_o1_v02
+DetectorModel = l5_o2_v02
 
 [SingleParticle]
 InputDirectory = /nfs/dust/ilc/user/ueinhaus/work/dEdx/mc-opt-3/single_prnd

--- a/TimeOfFlight/config/Setup.cnf
+++ b/TimeOfFlight/config/Setup.cnf
@@ -4,7 +4,7 @@ ILDConfigVersion = 02-00-01
 OutputBase       = output
 
 [Experiment]
-DetectorModel = l5_o2_v02
+DetectorModel = l5_o1_v02
 
 [SingleParticle]
 InputDirectory = /nfs/dust/ilc/user/ueinhaus/work/dEdx/mc-opt-3/single_prnd

--- a/TimeOfFlight/config/Setup.cnf
+++ b/TimeOfFlight/config/Setup.cnf
@@ -1,0 +1,13 @@
+[Environment]
+ILCSoftVersion   = 02-00-01
+ILDConfigVersion = 02-00-01
+OutputBase       = output
+
+[Experiment]
+DetectorModel = l5_o1_v02
+
+[SingleParticle]
+InputDirectory = /nfs/dust/ilc/user/ueinhaus/work/dEdx/mc-opt-3/single_prnd
+
+[ttbar]
+InputDirectory =

--- a/TimeOfFlight/config/TOFApproaches.cnf
+++ b/TimeOfFlight/config/TOFApproaches.cnf
@@ -1,0 +1,11 @@
+[ch]
+name_l = Closest Hits
+colour = 630
+
+[fh]
+name_l = First Hit
+colour = 597
+
+[th]
+name_l = Last Tracker Hit
+colour = 414

--- a/TimeOfFlight/config/TimeResolutions.cnf
+++ b/TimeOfFlight/config/TimeResolutions.cnf
@@ -1,0 +1,11 @@
+[0]
+unit   = ps
+colour = 600
+
+[10]
+unit   = ps
+colour = 417
+
+[50]
+unit   = ps
+colour = 634

--- a/TimeOfFlight/macros/creating_lctuples/SetSteeringFile.py
+++ b/TimeOfFlight/macros/creating_lctuples/SetSteeringFile.py
@@ -15,10 +15,6 @@ def get_TOF_branches_string(resolution):
 def main(args):
   template = args.steering_template
   
-  
-  # TODO get all TOF branches
-  # TODO Figure out how to read array of unknown size of input parameters
-  
   TOF_branches = [get_TOF_branches_string(tof_resolution) for tof_resolution in args.resolutions] #TODO Somewhere make sure its in ps!!!
   
   parameter_map = {

--- a/TimeOfFlight/macros/creating_lctuples/SetSteeringFile.py
+++ b/TimeOfFlight/macros/creating_lctuples/SetSteeringFile.py
@@ -1,0 +1,49 @@
+# Needs to be run with Python3 !
+import argparse
+import sys
+
+#-------------------------------------------------------------------------------
+
+def get_TOF_branches_string(resolution):
+  TOF_branches_string = """Algorithm:TOFEstimators{}ps tof{}
+                           TOFFirstHit TOFClosestHits TOFClosestHitsError TOFFlightLength TOFLastTrkHit TOFLastTrkHitFlightLength
+                           fh          ch             che                 len             th            thl \n""".format(resolution,resolution)
+  return TOF_branches_string
+ 
+#-------------------------------------------------------------------------------
+
+def main(args):
+  template = args.steering_template
+  
+  
+  # TODO get all TOF branches
+  # TODO Figure out how to read array of unknown size of input parameters
+  
+  TOF_branches = [get_TOF_branches_string(tof_resolution) for tof_resolution in args.resolutions] #TODO Somewhere make sure its in ps!!!
+  
+  parameter_map = {
+    'INPUT_FILES'      : ' '.join(args.input_files),
+    'OUTPUT_FILE_BASE' : args.output_base,
+    'TOF_PID_BRANCHES' : ' '.join(TOF_branches),
+  }
+  
+  with open(args.steering_template, "r") as template_file:
+    steering_template = template_file.read()
+    with open(args.result_path,'w') as steering_file:
+      print("Creating {}".format(args.result_path))
+      steering_file.write(steering_template.format(**parameter_map))
+
+#-------------------------------------------------------------------------------
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description = 'Config file reader')
+  parser.add_argument('--steering_template',             help='Name of the template steering file')
+  parser.add_argument('--input_files',        nargs='*', help='List of input slcio files')
+  parser.add_argument('--output_base',                   help='')
+  parser.add_argument('--resolutions',        nargs='*', help='List of time resolutions')
+  parser.add_argument('--result_path',                   help='Path to with the resulting steering file should be written')
+  
+  args = parser.parse_args()
+  sys.exit(main(args))
+
+#-------------------------------------------------------------------------------

--- a/TimeOfFlight/macros/creating_lctuples/run_singleparticle_lctuple.sh
+++ b/TimeOfFlight/macros/creating_lctuples/run_singleparticle_lctuple.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# TODO NEEDS PYTHON3 AND ILCSOFT (DUH)
+
+# Read input parameters
+RUN_ON_CONDOR=true
+
+for i in "$@" 
+do
+  case $i in
+    --no-bird)
+    RUN_ON_CONDOR=false
+    ;;
+    *)
+    # Unknown option
+    ;;
+  esac
+done
+
+# Python3 is needed -> Specify available command version
+PYTHON3="python3.4"
+
+# Directory environment (where to find stuff)
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )" # Directory of this script
+config_reader="${dir}/../reading_config/ReadConfig.py"
+scripts_dir="${dir}/../../scripts"
+template_file="${scripts_dir}/template_lctuple_steering_singleparticle.py"
+
+submit_file_dir="${dir}/../submitting_bird_jobs"
+submit_file_path="${submit_file_dir}/standard_htcondor_steering.submit"
+bird_output_dir="${dir}/../../BIRD_output"
+if [[ ! -d ${bird_output_dir} ]]; then
+  mkdir --parents ${bird_output_dir}
+fi
+
+# Get configurated options
+input_path=$(${PYTHON3} ${config_reader} --conf_file Setup.cnf --format single_value --key SingleParticle --variables InputDirectory)
+ilcsoft_ver=$(${PYTHON3} ${config_reader} --conf_file Setup.cnf --format single_value --key Environment --variables ILCSoftVersion)
+ildconf_ver=$(${PYTHON3} ${config_reader} --conf_file Setup.cnf --format single_value --key Environment --variables ILDConfigVersion)
+detector_model=$(${PYTHON3} ${config_reader} --conf_file Setup.cnf --format single_value --key Experiment --variables DetectorModel)
+output_base="${dir}/../../$(${PYTHON3} ${config_reader} --conf_file Setup.cnf --format single_value --key Environment --variables OutputBase)"
+
+time_resolutions="$(${PYTHON3} ${config_reader} --conf_file TimeResolutions.cnf --format list_of_keys)"
+
+# Directory structures derived from configuration
+run_base="SingleParticle_rv${ilcsoft_ver}_sv${ildconf_ver}_mILD_${detector_model}"
+run_steering_dir="${scripts_dir}/${run_base}"
+run_output_dir="${output_base}/${run_base}"
+
+if [[ ! -d ${run_steering_dir} ]]; then
+  mkdir --parents ${run_steering_dir}
+fi
+if [[ ! -d ${run_output_dir} ]]; then
+  mkdir --parents ${run_output_dir}
+fi
+
+# Loop to run lctuple for each particle type
+# TODO CHANGE CONVENTION OF LCTUPLE FILE NAMES IN PLOTTING SCRIPTS
+for ptype in $(${PYTHON3} ${config_reader} --conf_file ParticleTypes.cnf --format list_of_variables --variables pdgID); do
+  echo "Starting to run single particle jobs for particle type: ${ptype}"
+  {
+    # Uses file convention for single particle files
+    files=$(find ${input_path} -iname "*rv${ilcsoft_ver}*sv${ildconf_ver}*mILD_${detector_model}*calib*pm${ptype}_prnd*e0.p0*rec*.slcio" -print)
+    
+    type_output_base="${run_output_dir}/${ptype}"
+    
+    if $RUN_ON_CONDOR; then
+      echo "Will run jobs on BIRD cluster."
+      type_steering_dir="${run_steering_dir}/${ptype}"
+      type_output_dir="${type_output_base}"
+      
+      if [[ ! -d ${type_steering_dir} ]]; then
+        mkdir --parents ${type_steering_dir}
+      fi
+      if [[ ! -d ${type_output_dir} ]]; then
+        mkdir --parents ${type_output_dir}
+      fi
+
+      # Send Marlin job to HTCondor for each individual input file
+      file_index=0
+      for file in ${files[@]}; do
+        {
+          steering_path="${type_steering_dir}/${file_index}.xml"
+          lctuple_output_base="${type_output_dir}/${file_index}"
+
+          ${PYTHON3} SetSteeringFile.py --steering_template ${template_file} --input_files ${file} --output_base ${lctuple_output_base} --resolutions ${time_resolutions} --result_path ${steering_path}
+          
+          # Submit job and wait for it
+          cd ${submit_file_dir}
+          condor_job_output=$(condor_submit ${submit_file_path} arguments="source ${ILCSOFT}/init_ilcsoft.sh \&\& Marlin ${steering_path}")
+          job_ID="${condor_job_output##* }"
+          job_log_path=$(ls ${bird_output_dir}/${job_ID}*.log)
+          wait_output=$(condor_wait ${job_log_path}) # Write into variable to suppress spammy output
+          cd -
+        } > ${type_steering_dir}/${file_index}.log 2>&1 & 
+        file_index=$((file_index + 1))
+        sleep 0.1 # to avoid machine spamming and scheduler overload
+      done
+      wait
+      
+      # Combine results of individual lctuples
+      echo "All individual lctuples done, combining them."
+      hadd -k -f ${type_output_base}_lctuple.root ${type_output_dir}/*.root
+      rm -r ${type_output_dir}
+    else
+      # When running on local machine (Not recommended)
+      echo "Will run jobs on local machine."
+      steering_path="${run_steering_dir}/${ptype}_all.xml"
+      lctuple_output_base="${type_output_base}_lctuple"
+
+      ${PYTHON3} SetSteeringFile.py --steering_template ${template_file} --input_files ${files} --output_base ${lctuple_output_base} --resolutions ${time_resolutions} --result_path ${steering_path}
+      Marlin ${steering_path}
+    fi
+  } > ${run_steering_dir}/${ptype}.log 2>&1 &
+  sleep 10 # to avoid machine spamming and scheduler overload
+done
+wait
+echo "Done with all particle types!"

--- a/TimeOfFlight/macros/creating_lctuples/run_singleparticle_lctuple.sh
+++ b/TimeOfFlight/macros/creating_lctuples/run_singleparticle_lctuple.sh
@@ -45,7 +45,7 @@ time_resolutions="$(${PYTHON3} ${config_reader} --conf_file TimeResolutions.cnf 
 # Directory structures derived from configuration
 run_base="SingleParticle_rv${ilcsoft_ver}_sv${ildconf_ver}_mILD_${detector_model}"
 run_steering_dir="${scripts_dir}/${run_base}"
-run_output_dir="${output_base}/${run_base}"
+run_output_dir="${output_base}/${run_base}/lctuple"
 
 if [[ ! -d ${run_steering_dir} ]]; then
   mkdir --parents ${run_steering_dir}
@@ -55,7 +55,6 @@ if [[ ! -d ${run_output_dir} ]]; then
 fi
 
 # Loop to run lctuple for each particle type
-# TODO CHANGE CONVENTION OF LCTUPLE FILE NAMES IN PLOTTING SCRIPTS
 for ptype in $(${PYTHON3} ${config_reader} --conf_file ParticleTypes.cnf --format list_of_variables --variables pdgID); do
   echo "Starting to run single particle jobs for particle type: ${ptype}"
   {
@@ -83,7 +82,7 @@ for ptype in $(${PYTHON3} ${config_reader} --conf_file ParticleTypes.cnf --forma
           steering_path="${type_steering_dir}/${file_index}.xml"
           lctuple_output_base="${type_output_dir}/${file_index}"
 
-          ${PYTHON3} SetSteeringFile.py --steering_template ${template_file} --input_files ${file} --output_base ${lctuple_output_base} --resolutions ${time_resolutions} --result_path ${steering_path}
+          ${PYTHON3} ${dir}/SetSteeringFile.py --steering_template ${template_file} --input_files ${file} --output_base ${lctuple_output_base} --resolutions ${time_resolutions} --result_path ${steering_path}
           
           # Submit job and wait for it
           cd ${submit_file_dir}
@@ -108,7 +107,7 @@ for ptype in $(${PYTHON3} ${config_reader} --conf_file ParticleTypes.cnf --forma
       steering_path="${run_steering_dir}/${ptype}_all.xml"
       lctuple_output_base="${type_output_base}_lctuple"
 
-      ${PYTHON3} SetSteeringFile.py --steering_template ${template_file} --input_files ${files} --output_base ${lctuple_output_base} --resolutions ${time_resolutions} --result_path ${steering_path}
+      ${PYTHON3} ${dir}/SetSteeringFile.py --steering_template ${template_file} --input_files ${files} --output_base ${lctuple_output_base} --resolutions ${time_resolutions} --result_path ${steering_path}
       Marlin ${steering_path}
     fi
   } > ${run_steering_dir}/${ptype}.log 2>&1 &

--- a/TimeOfFlight/macros/creating_lctuples/run_singleparticle_lctuple.sh
+++ b/TimeOfFlight/macros/creating_lctuples/run_singleparticle_lctuple.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# TODO NEEDS PYTHON3 AND ILCSOFT (DUH)
-
 # Read input parameters
 RUN_ON_CONDOR=true
 

--- a/TimeOfFlight/macros/plotting/draw_tof_singleparticle.cpp
+++ b/TimeOfFlight/macros/plotting/draw_tof_singleparticle.cpp
@@ -128,6 +128,12 @@ void draw_tof_singleparticle(const string ConfigDir="../..", const string InFile
           
           double p = slice_p1.p;
           
+          if ( ! (slice_p1.fit_successful && slice_p2.fit_successful) ) {
+            cout << ptype1.name_l << " - " << ptype2.name_l << ", " << res.w_unit() << 
+                    " : Fit in slice p=" << p << " not successful, point won't be drawn." << endl;
+            continue;
+          }
+          
           double diff_mean     = abs(slice_p1.mean - slice_p2.mean);
           double sigma_sqr_sum = pow(slice_p1.sigma, 2) + pow(slice_p2.sigma, 2); 
           double ms_sigma      = sigma_sqr_sum / 2.0; // ms = mean squared 

--- a/TimeOfFlight/macros/plotting/draw_tof_singleparticle.cpp
+++ b/TimeOfFlight/macros/plotting/draw_tof_singleparticle.cpp
@@ -1,9 +1,13 @@
 #include "tof_helpers.cpp"
 #include "../reading_config/read_config.cpp"
 
-void draw_tof_singleparticle(const string InFileBase = "", const string OutFileBase = "SP") {
+void draw_tof_singleparticle(const string ConfigDir="../..", const string InFileBase = "../../output/SingleParticle_rv02-00-01_sv02-00-01_mILD_l5_o1_v02/", const string OutFileBase = "../../output/SP") {
+  // TODO Change input and output paths
  
-  ConfigReader ptype_reader("../../config/ParticleTypes.cnf"); // TODO Collect config strings in beginning
+ string ptype_config_path = ConfigDir + "/ParticleTypes.cnf";
+ string res_config_path   = ConfigDir + "/TimeResolutions.cnf";
+ 
+  ConfigReader ptype_reader(ptype_config_path);
   ParticleVec particle_types {};
   auto ptype_names = ptype_reader.get_keys();
   for (auto & ptype_name: ptype_names) { 
@@ -11,7 +15,7 @@ void draw_tof_singleparticle(const string InFileBase = "", const string OutFileB
     particle_types.push_back( ParticleType(stoi(ptype_sec["pdgID"]), ptype_sec["name_s"],  ptype_name, stod(ptype_sec["mass"]), stoi(ptype_sec["colour"])) );
   }
   
-  ConfigReader res_reader("../../config/TimeResolutions.cnf"); // TODO Collect config strings in beginning
+  ConfigReader res_reader(res_config_path);
   ResVec resolutions {};
   auto res_values = res_reader.get_keys();
   for (auto & res_value: res_values) {
@@ -19,7 +23,6 @@ void draw_tof_singleparticle(const string InFileBase = "", const string OutFileB
     resolutions.push_back( Resolution(stof(res_value), stoi(res_sec["colour"])) );
   }
   
-  // TODO FROM HERE: Change input and output paths
   
   HistoMap beta_histos {};
   
@@ -28,7 +31,6 @@ void draw_tof_singleparticle(const string InFileBase = "", const string OutFileB
       beta_histos.addHisto( ptype, res );
     }
   }
-
   // TODO Also loop over different time estimators?? (Here: CH -> Closest Hit)
 
   unique_ptr<TCanvas> c_dummy {new TCanvas("dummy","",1000,800)}; // To write histos to that don't need to be written to current canvas

--- a/TimeOfFlight/macros/plotting/draw_tof_singleparticle.cpp
+++ b/TimeOfFlight/macros/plotting/draw_tof_singleparticle.cpp
@@ -2,8 +2,6 @@
 #include "../reading_config/read_config.cpp"
 
 void draw_tof_singleparticle(const string ConfigDir="../..", const string InFileBase = "../../output/SingleParticle_rv02-00-01_sv02-00-01_mILD_l5_o1_v02/", const string OutFileBase = "../../output/SP") {
-  // TODO Change input and output paths
- 
  string ptype_config_path = ConfigDir + "/ParticleTypes.cnf";
  string res_config_path   = ConfigDir + "/TimeResolutions.cnf";
  

--- a/TimeOfFlight/macros/plotting/draw_tof_singleparticle.cpp
+++ b/TimeOfFlight/macros/plotting/draw_tof_singleparticle.cpp
@@ -1,0 +1,183 @@
+#include "tof_helpers.cpp"
+#include "../reading_config/read_config.cpp"
+
+void draw_tof_singleparticle(const string InFileBase = "", const string OutFileBase = "SP") {
+ 
+  ConfigReader ptype_reader("../../config/ParticleTypes.cnf"); // TODO Collect config strings in beginning
+  ParticleVec particle_types {};
+  auto ptype_names = ptype_reader.get_keys();
+  for (auto & ptype_name: ptype_names) { 
+    auto ptype_sec = ptype_reader[ptype_name]; // Section 
+    particle_types.push_back( ParticleType(stoi(ptype_sec["pdgID"]), ptype_sec["name_s"],  ptype_name, stod(ptype_sec["mass"]), stoi(ptype_sec["colour"])) );
+  }
+  
+  ConfigReader res_reader("../../config/TimeResolutions.cnf"); // TODO Collect config strings in beginning
+  ResVec resolutions {};
+  auto res_values = res_reader.get_keys();
+  for (auto & res_value: res_values) {
+    auto res_sec = res_reader[res_value]; 
+    resolutions.push_back( Resolution(stof(res_value), stoi(res_sec["colour"])) );
+  }
+  
+  // TODO FROM HERE: Change input and output paths
+  
+  HistoMap beta_histos {};
+  
+  for ( auto &ptype : particle_types ) {
+    for ( auto &res : resolutions) {
+      beta_histos.addHisto( ptype, res );
+    }
+  }
+
+  // TODO Also loop over different time estimators?? (Here: CH -> Closest Hit)
+
+  unique_ptr<TCanvas> c_dummy {new TCanvas("dummy","",1000,800)}; // To write histos to that don't need to be written to current canvas
+
+  unique_ptr<TCanvas> c_beta_p {new TCanvas("c","#beta_{CH} vs momentum",1000,800)}; 
+  c_beta_p->Clear();
+  c_beta_p->Divide(resolutions.size(), particle_types.size());
+  int i_pad=1;
+
+  int bins_p = 2000, bins_beta = 200;
+  float min_p = 0,   max_p = 100;
+  float min_beta = 0.5, max_beta = 1.05;
+  
+  int bins_per_slice = 10;
+  
+  // Get the beta vs p histograms and save for each particle type
+  for ( auto & ptype : particle_types ) {
+    TFile* file = new TFile ( ( InFileBase + to_string(ptype.pdg_id) + "_lctuple.root" ).c_str() ,"r") ;
+    TTree* tree = (TTree*) file->Get("MyLCTuple");
+    
+    for (auto &res : resolutions) {
+      c_beta_p->cd(i_pad++);
+
+      string h_beta_name = "h_beta_" + ptype.name_s + "_" + res.str();
+
+      TH2F *h_beta = new TH2F( h_beta_name.c_str(),
+                              ("#beta_{CH} vs momentum, " + ptype.name_l + ", " + res.w_unit() + "; p [GeV/c] ; #beta ").c_str(),
+                              bins_p, min_p, max_p, bins_beta, min_beta, max_beta
+                             );
+      
+      string tof_res = "tof" + res.str();
+      string draw_string = tof_res + "len/" + tof_res + "ch/299.8:sqrt(rcmox*rcmox+rcmoy*rcmoy+rcmoz*rcmoz)>>" + h_beta_name;
+      string cut_string  = tof_res + "len>1.&&" + tof_res + "ch>0.1&&(" + tof_res + "len/" + tof_res + "ch/299.8)<1.1 && sqrt(rcmox*rcmox+rcmoy*rcmoy+rcmoz*rcmoz)<100.&&abs(rccha)>0.005 && abs(rcmoz)/sqrt(rcmox*rcmox+rcmoy*rcmoy+rcmoz*rcmoz) < 0.792573 && sqrt(rcmox*rcmox+rcmoy*rcmoy) > 0.948543 && nrec==1";
+        
+      tree->Draw( draw_string.c_str(), cut_string.c_str() );
+
+      TF1* beta_func = new TF1( ("beta_func_" + ptype.name_s + "_" + res.str()).c_str(), "x / sqrt(x^2 + [0]^2)", min_p, max_p);
+      beta_func->SetParameter(0, ptype.mass);
+      beta_func->Draw("same");
+      beta_func->SetLineColor(kRed+1);
+      
+      c_dummy->cd();
+      beta_histos.getHisto(res, ptype)->histo = h_beta;
+      beta_histos.getHisto(res, ptype)->slice_histo(bins_per_slice);
+    }
+    // file->Close();
+  }
+  c_beta_p->Print( (OutFileBase + "_beta_p.pdf").c_str() );
+  
+
+  // Save the sliced histograms
+  for ( auto & res: resolutions ) {
+    unique_ptr<TFile> file_slices { new TFile( (OutFileBase + "_slices_" + res.w_unit() + ".root").c_str(), "RECREATE" ) };
+
+    for ( auto & histo: beta_histos.getHistosToRes(res) ) {
+      for ( auto & slice: histo->slices ) {
+        slice.histo->Write();
+      }
+    }
+    file_slices->Close();
+  }
+  
+  
+  unique_ptr<TFile> file_sep_pwr { new TFile( (OutFileBase + "_separation_powers.root").c_str(), "RECREATE" ) };
+  // Find separation power for all combinations 
+  int N_ptypes = particle_types.size();
+  for (int i=0; i<N_ptypes-1; i++) {
+    if ( 1 == N_ptypes ) {
+      cout << "Only one particle type given, not creating separation power plots." << endl;
+      break;
+    }
+    for (int j=i+1; j<N_ptypes; j++) { // Loop avoids dublicats
+      ParticleType ptype1 = particle_types[i];
+      ParticleType ptype2 = particle_types[j];
+      
+      unique_ptr<TCanvas> c_sep_pwr {new TCanvas( ("c_sep_pwr_" + ptype1.name_s + "_" + ptype2.name_s).c_str() ,
+                                                  "Separation power vs momentum",
+                                                  800*resolutions.size(),800)}; 
+      c_sep_pwr->Divide(resolutions.size(), 1);
+      int i_seppwr_pad = 1;
+      
+      vector<pair<Resolution,TH1D*>> sep_pwr_hists {};
+      
+      for ( auto & res: resolutions ) {
+        auto slices_p1 = beta_histos.getHisto(res, ptype1)->slices;
+        auto slices_p2 = beta_histos.getHisto(res, ptype2)->slices;
+      
+        int N_slices = slices_p1.size();
+        
+        TH1D* h_seppwr = new TH1D(("h_seppwr_" + ptype1.name_s + ptype2.name_s + res.str()).c_str(), 
+                                  (ptype1.name_l + " - " + ptype2.name_l + " TOF-separation, " + res.w_unit() + "; p [GeV/c] ; Separation Power [#sigma]").c_str(),
+                                  N_slices, min_p, max_p);
+                                  
+        for (int i_slice=0; i_slice<N_slices; i_slice++) {
+          auto slice_p1 = slices_p1[i_slice];
+          auto slice_p2 = slices_p2[i_slice];
+          
+          double p = slice_p1.p;
+          
+          double diff_mean     = abs(slice_p1.mean - slice_p2.mean);
+          double sigma_sqr_sum = pow(slice_p1.sigma, 2) + pow(slice_p2.sigma, 2); 
+          double ms_sigma      = sigma_sqr_sum / 2.0; // ms = mean squared 
+          double rms_sigma     = sqrt( ms_sigma );    // rms = root mean squared
+          
+          double sep_pwr     = diff_mean / rms_sigma;
+          double sep_pwr_err = sqrt( (pow(slice_p1.mean_err,2) + pow(slice_p2.mean_err,2))/ms_sigma + pow(diff_mean,2) * (pow(slice_p1.sigma,2)*pow(slice_p1.sigma_err,2) + pow(slice_p2.sigma,2)*pow(slice_p2.sigma_err,2)) / (4*pow(ms_sigma,3)) );
+          // Check that sep pwr is not NaN
+          if ( sep_pwr != sep_pwr) { sep_pwr = sep_pwr_err = 0; }
+          
+          h_seppwr->SetBinContent(h_seppwr->FindBin(p), sep_pwr);
+          h_seppwr->SetBinError(  h_seppwr->FindBin(p), sep_pwr_err);
+        }          
+        
+        h_seppwr->Write();
+        
+        c_sep_pwr->cd(i_seppwr_pad++);
+        h_seppwr->Draw("hist e");
+        h_seppwr->SetMinimum(0);
+        h_seppwr->SetMaximum(40);
+        
+        sep_pwr_hists.push_back(make_pair(res,h_seppwr));
+      }
+      c_sep_pwr->Write();
+      
+      unique_ptr<TCanvas> c_sep_pwr_comb {  new TCanvas( ("c_sep_pwr_comb_" + ptype1.name_s + "_" + ptype2.name_s).c_str() ,
+                                                          "Separation power vs momentum",
+                                                          800,800)
+                                          };
+      unique_ptr<THStack> h_sep_pwr_comb { new THStack(
+                                                ("h_seppwr_comb_" + ptype1.name_s + ptype2.name_s).c_str(), 
+                                                (ptype1.name_l + " - " + ptype2.name_l + " TOF-separation; p [GeV/c] ; Separation Power [#sigma]").c_str())
+                                          };
+      unique_ptr<TLegend> leg_sep_pwr_comb { new TLegend(0.48,0.7,0.8,0.9) };
+      for (auto &res_hist: sep_pwr_hists) {
+        Resolution res  = res_hist.first;
+        TH1D* h_seppwr  = res_hist.second;
+        leg_sep_pwr_comb->AddEntry(h_seppwr, res.w_unit().c_str(), "lep");
+        h_sep_pwr_comb->Add(h_seppwr);
+        h_seppwr->SetLineColor(res.colour_index);
+      }
+      h_sep_pwr_comb->Draw("nostack");
+      h_sep_pwr_comb->SetMinimum(0);
+      if( h_sep_pwr_comb->GetMaximum() > 120 ) { h_sep_pwr_comb->SetMaximum(100); }
+      gPad->Modified();
+      gPad->Update();
+      leg_sep_pwr_comb->Draw();
+      c_sep_pwr_comb->Write(); 
+    }
+  }
+  file_sep_pwr->Close();
+
+}

--- a/TimeOfFlight/macros/plotting/draw_tof_ttbar.cpp
+++ b/TimeOfFlight/macros/plotting/draw_tof_ttbar.cpp
@@ -1,0 +1,238 @@
+#include "tof_helpers.cpp"
+
+// TODO More status reports!!!
+// TODO CHANGE DEFAULT IN FILE NAME
+void draw_tof_ttbar( const string InFile = "lctuplep.root", const string OutFileBase = "ttbar" ){
+
+  ParticleVec particle_types {};
+  particle_types.push_back( ParticleType(2212, "p",  "Proton", 0.938272, kRed+1) );
+  particle_types.push_back( ParticleType(321,  "K",  "Kaon", 0.493677, kGreen+2) );
+  particle_types.push_back( ParticleType(211,  "Pi", "Pion", 0.13957, kViolet) );
+  particle_types.push_back( ParticleType(11,   "e1", "Electron", 0.000511, kCyan+1) );
+  particle_types.push_back( ParticleType(13,   "e2", "Muon", 0.1056584, kBlue-3) );
+
+  ResVec resolutions {};
+  resolutions.push_back( Resolution(0,  kBlue) );
+  resolutions.push_back( Resolution(10, kGreen+1) );
+  resolutions.push_back( Resolution(50, kRed+2) );
+  
+  HistoMap beta_histos {};
+  ParticleType ttbar = ParticleType("ttbar", "ttbar");
+  for ( auto &res : resolutions) {
+    beta_histos.addHisto( ttbar, res );
+  }
+  
+  int bins_per_slice = 10;
+  
+  unique_ptr<TCanvas> c_dummy {new TCanvas("dummy","",1000,800)}; // To write histos to that don't need to be written to current canvas
+  
+  unique_ptr<TFile> file { new TFile (InFile.c_str(),"r") };
+  TTree* tree = (TTree*) file->Get("MyLCTuple");
+
+  unique_ptr<TFile> file_all_ptypes { new TFile( (OutFileBase + "_all_particles.root").c_str(), "RECREATE" ) };
+
+  for (auto &res : resolutions) {
+
+    unique_ptr<TCanvas> c_beta_p { new TCanvas( ("c_beta_p_" + res.str()).c_str(),
+                                                ("#beta vs momentum, ttbar, " + res.w_unit()).c_str(),
+                                                500,500) }; //(plot, name, [ 10, -5, -10 100 all looks same] )
+    c_beta_p->Clear();
+
+    string h_beta_name = "h_beta_" + res.str();
+    TH2F *h_beta = new TH2F( h_beta_name.c_str(),
+                             ("#beta vs momentum, ttbar, " + res.w_unit()).c_str(), 
+                             200, 0, 10., 200, 0.5, 1.); // (plot ,name ,nbin x ,x low ,x up ,nbin y ,y low ,y up)   
+                             
+    string tof_res = "tof" + res.str();
+    string draw_string = tof_res + "len/" + tof_res + "ch/299.8:sqrt(rcmox*rcmox+rcmoy*rcmoy+rcmoz*rcmoz)>>" + h_beta_name;
+    string cut_string  = tof_res + "len>1.&&" + tof_res + "ch>0.1&&(" + tof_res + "len/" + tof_res + "ch/299.8)<1.1 && sqrt(rcmox*rcmox+rcmoy*rcmoy+rcmoz*rcmoz)<10.&&abs(rccha)>0.01";
+    tree->Draw( draw_string.c_str(), cut_string.c_str() );
+
+    h_beta->Write();
+
+    for ( auto & ptype : particle_types ) {
+      TF1* beta_func = new TF1( ("beta_func_" + ptype.name_l).c_str(), "x / sqrt(x^2 + [0]^2)", 0., 10);
+      beta_func->SetParameter(0, ptype.mass);
+      beta_func->Draw("same");
+      beta_func->SetLineColor(ptype.colour_index);
+      
+    }
+    c_beta_p->Update();
+    c_beta_p->Write();
+    c_beta_p->Close();
+    
+    // c_dummy->cd();
+    beta_histos.getHisto(res, ttbar)->histo = h_beta;
+    beta_histos.getHisto(res, ttbar)->slice_histo(bins_per_slice, false);
+    
+    int N_slices = beta_histos.getHisto(res, ttbar)->slices.size();
+    unique_ptr<TCanvas> c_beta_p_slices { new TCanvas(  ("c_beta_p_slices_" + res.str()).c_str(),
+                                                        ("#beta, p slices, ttbar, " + res.w_unit()).c_str(),
+                                                        500*N_slices,500) }; //(plot, name, [ 10, -5, -10 100 all looks same] )
+    c_beta_p_slices->Divide(N_slices, 1);
+    int i_pad = 1;
+    
+    unique_ptr<TDirectory> dir_slices { file_all_ptypes->mkdir( ("slices_" + res.str()).c_str() ) };
+    for ( auto & slice: beta_histos.getHisto(res, ttbar)->slices ) {
+      c_beta_p_slices->cd(i_pad++);
+      slice.histo->Draw();
+      
+      for ( auto & ptype : particle_types ) {
+        double p = slice.p;
+        double beta = p/sqrt(ptype.mass*ptype.mass + p*p);
+        TLine *line = new TLine(beta,0.0,beta,1000);
+        line->SetLineColor(ptype.colour_index);
+        line->Draw();
+      }
+      
+      dir_slices->cd();
+      slice.histo->Write();
+    }
+    dir_slices->Write();
+    file_all_ptypes->cd();
+    c_beta_p_slices->Update();
+    c_beta_p_slices->Write();
+    c_beta_p_slices->Close();
+  }
+  
+  file_all_ptypes->Close();
+  
+  //////////////////////////////////////////////////////////////////////////////
+  unique_ptr<TFile> file_diff { new TFile( (OutFileBase + "_tof_diffs.root").c_str(), "RECREATE" ) };
+
+  MethodVec tof_methods {}; // TODO Move this to start and make universal also in other draw
+  tof_methods.push_back(Method("ch", "Closest Hits"));
+  tof_methods.push_back(Method("fh", "First Hit"));
+  tof_methods.push_back(Method("th", "Last Tracker Hit"));
+
+  for (int i=0; i<resolutions.size()-1; i++) {
+    if ( 1 == resolutions.size() ) {
+      cout << "Only one resolution given, not creating difference plots." << endl;
+      break;
+    }
+    Resolution res_1 = resolutions[i];
+    
+    for (int j=i+1; j<resolutions.size(); j++) {
+      Resolution res_2 = resolutions[j];
+    
+      for ( auto & method: tof_methods ) {
+        unique_ptr<TCanvas> c_tof_diff { new TCanvas( ("c_tof_diff_" + res_1.str() + res_2.str() + method.name_s).c_str(),
+                                                      ("TOF difference " + method.name_l + ", " + res_1.w_unit() + "-" + res_2.w_unit()).c_str(),
+                                                      500, 500) };
+        c_tof_diff->Clear(); 
+        string h_diff_name = "h_tof_diff_" + res_1.str() + res_2.str() + method.name_s;
+        TH1D *h_tof_diff = new TH1D(  h_diff_name.c_str(),
+                                      ("#Delta TOF_{" + method.name_s + "}, " + res_1.w_unit() + "-" + res_2.w_unit() + "; #Delta TOF; #").c_str(), 
+                                      1000, -1. ,1.);
+        
+                                      
+        string draw_string = "tof" + res_1.str() + method.name_s + "-tof" + res_2.str() + method.name_s + ">>" + h_diff_name;
+        string cut_string  = "tof" + res_1.str() + method.name_s + " != -1 && tof" + res_2.str() + method.name_s + " != -1";
+        tree->Draw(draw_string.c_str(), cut_string.c_str());
+        
+        c_tof_diff->Update();
+        c_tof_diff->Write();
+      } 
+    }
+  }
+
+  file_diff->Close();
+
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  const int max_N_rec = 3000;
+  
+  Int_t nmcp;
+  Int_t mcpdg[max_N_rec];
+  Int_t N_rec;
+  Float_t rcmox[max_N_rec], rcmoy[max_N_rec], rcmoz[max_N_rec], rccha[max_N_rec];
+
+  Int_t r2mnrel, r2mf[max_N_rec], r2mt[max_N_rec];
+  Float_t r2mw[max_N_rec];
+  Float_t m2rw[max_N_rec];
+   
+  tree->SetBranchAddress("nmcp",&nmcp);
+  tree->SetBranchAddress("mcpdg",&mcpdg);
+  tree->SetBranchAddress("nrec",&N_rec);
+  tree->SetBranchAddress("rcmox",rcmox);
+  tree->SetBranchAddress("rcmoy",rcmoy);
+  tree->SetBranchAddress("rcmoz",rcmoz);
+  tree->SetBranchAddress("rccha",rccha);
+  tree->SetBranchAddress("r2mnrel",&r2mnrel);
+  tree->SetBranchAddress("r2mf",&r2mf);
+  tree->SetBranchAddress("r2mt",&r2mt);
+  tree->SetBranchAddress("r2mw",&r2mw);
+  
+  int N_entries = tree->GetEntries();
+  
+  unique_ptr<TFile> file_individual_ptypes { new TFile( (OutFileBase + "_individual_types.root").c_str(), "RECREATE" ) };
+  
+  for ( auto & res: resolutions ) {
+    Float_t tof_len[max_N_rec];
+    Float_t tof_ch[max_N_rec];
+    tree->SetBranchAddress( ("tof" + res.str() + "len").c_str()  ,&tof_len);
+    tree->SetBranchAddress( ("tof" + res.str() + "ch").c_str()   ,&tof_ch );
+    
+    for ( auto & ptype: particle_types ) {
+      
+      // TODO delete or make unique
+      TH2F *h_beta_p = new TH2F(  ("ttbar_beta_p_" + ptype.name_s + "_" + res.str()).c_str(),
+                                  ("#beta vs p, " + ptype.name_l + ", " + res.w_unit() + "; p; #beta; #" + ptype.name_l).c_str(),
+                                  200, 0, 10., 200, 0.5, 1.05 );
+        
+                                  // for (int i=0; i< 566; i++)
+      for (int i=0; i<N_entries; i++) {
+        tree->GetEntry(i);
+       
+        for (int i_rec=0; i_rec<N_rec; i_rec++) {
+          Double_t weight = 0.0;
+          Double_t calweight;
+          Int_t i_mc = -1;
+          int final_i_rel = -1;
+          
+          for (int k=0; k<r2mnrel; k++) {
+            if (r2mf[k] == i_rec) {     
+              calweight =  double((int(r2mw[k])/10000)/1000.);
+              if (calweight > weight) {
+                final_i_rel = k ;
+                weight = calweight;
+              }
+            }  
+          }
+          
+          if ( weight > 0.9 ) {
+
+            if (final_i_rel < 0 || final_i_rel >= r2mnrel ) {
+              cout << "ERROR: MCParticle index out of range: final = " << final_i_rel << ", r2mnrel = " << r2mnrel << endl;
+              continue;
+            }
+            i_mc  = r2mt[final_i_rel];     
+
+            if (i_mc < 0 || i_mc >= nmcp ) {
+              cout << "ERROR: MCParticle index out of range: MCP = " << i_mc << ", nmcp = " << nmcp << endl;
+              continue; 
+            }
+
+            IntVec ptype_pdgs = pdg_map[ptype.name_s];
+            bool mc_is_ptype = ( find(ptype_pdgs.begin(), ptype_pdgs.end(), abs(mcpdg[i_mc])) != ptype_pdgs.end() );
+
+            if ( mc_is_ptype ) {
+              double p = sqrt(rcmox[i_rec]*rcmox[i_rec]+rcmoy[i_rec]*rcmoy[i_rec]+rcmoz[i_rec]*rcmoz[i_rec]);
+              double beta = (tof_len[i_rec]/tof_ch[i_rec]/299.8);
+
+              if ( beta <1.1 && p <10. && tof_len[i_rec]>1. && tof_ch[i_rec]>0.1 && abs(rccha[i_rec])>0.01 && abs(rcmoz[i_rec])/sqrt(rcmox[i_rec]*rcmox[i_rec]+rcmoy[i_rec]*rcmoy[i_rec]+rcmoz[i_rec]*rcmoz[i_rec]) > 0.79257283 ) {
+                h_beta_p->Fill(p, beta);	
+              }   
+            }
+          }
+        }
+      }
+      h_beta_p->Draw("box");
+      h_beta_p->Write();
+    }
+  }
+  file_individual_ptypes->Close();
+  
+  file->Close();
+}

--- a/TimeOfFlight/macros/plotting/run_singleparticle_plotting.sh
+++ b/TimeOfFlight/macros/plotting/run_singleparticle_plotting.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Python3 is needed -> Specify available command version
+PYTHON3="python3.4"
+
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )" # Directory of this script
+config_reader="${dir}/../reading_config/ReadConfig.py"
+config_dir="${dir}/../../config"
+
+# Get configurated options
+ilcsoft_ver=$(${PYTHON3} ${config_reader} --conf_file Setup.cnf --format single_value --key Environment --variables ILCSoftVersion)
+ildconf_ver=$(${PYTHON3} ${config_reader} --conf_file Setup.cnf --format single_value --key Environment --variables ILDConfigVersion)
+detector_model=$(${PYTHON3} ${config_reader} --conf_file Setup.cnf --format single_value --key Experiment --variables DetectorModel)
+lctuple_output_base="${dir}/../../$(${PYTHON3} ${config_reader} --conf_file Setup.cnf --format single_value --key Environment --variables OutputBase)"
+
+# Input/output paths
+run_base="${lctuple_output_base}/SingleParticle_rv${ilcsoft_ver}_sv${ildconf_ver}_mILD_${detector_model}" 
+run_input_base="${run_base}/lctuple/"
+run_output_dir="${run_base}/plots"
+run_output_base="${run_output_dir}/SP"
+
+if [[ ! -d ${run_output_dir} ]]; then
+  mkdir --parents ${run_output_dir}
+fi
+
+root -l -b -q ${dir}'/draw_tof_singleparticle.cpp("'${config_dir}'","'${run_input_base}'","'${run_output_base}'")' > ${run_output_dir}/plotting.log 2>&1

--- a/TimeOfFlight/macros/plotting/tof_helpers.cpp
+++ b/TimeOfFlight/macros/plotting/tof_helpers.cpp
@@ -1,0 +1,178 @@
+struct ParticleType {
+  int pdg_id {};
+  string name_s {};
+  string name_l {};
+  float mass {}; // in GeV
+  Color_t colour_index {};
+
+  ParticleType( int _pdg_id=0, string _name_s="", string _name_l="", float _mass=0, Color_t _colour_index=0 ) : 
+    pdg_id(_pdg_id), name_s(_name_s),  name_l(_name_l),  mass(_mass), colour_index(_colour_index) {};
+    
+  // Copy constructor
+  ParticleType(const ParticleType &_ptype) : 
+    pdg_id(_ptype.pdg_id), name_s(_ptype.name_s), name_l(_ptype.name_l), mass(_ptype.mass), colour_index(_ptype.colour_index) {};
+    
+  bool operator== (const ParticleType &ptype){
+    return pdg_id == ptype.pdg_id && name_s == ptype.name_s && name_l == ptype.name_l && mass == ptype.mass;
+  }
+};
+
+struct Resolution {
+  float value {};
+  string unit {};
+  Color_t colour_index {};
+  
+  Resolution( float _value=0, Color_t _colour_index=0 , string _unit="ps") :
+    value(_value), unit(_unit), colour_index(_colour_index) {};
+  
+  bool operator== (const Resolution &res){
+    return value == res.value && unit == res.unit;
+  }
+      
+  string str() const {
+    string value_str = to_string(value);
+    if ( roundf(value) == value ) { value_str = to_string(int(value)); }
+    return value_str;
+  }
+  
+  string w_unit() const {
+    return this->str() + unit;
+  }
+};
+
+struct Method {
+  string name_s {};
+  string name_l {};
+  Color_t colour_index {};
+  
+  Method( string _name_s="", string _name_l="", Color_t _colour_index=0 ) : 
+    name_s(_name_s), name_l(_name_l), colour_index(_colour_index) {};
+};
+
+struct Slice {
+  double p {};
+  TH1D* histo {};
+  double mean {};
+  double sigma {};
+  double mean_err {};
+  double sigma_err {};
+};
+
+struct Histo {
+  ParticleType ptype;
+  Resolution res;
+  TH2F* histo {};
+  vector<Slice> slices {};
+  
+  Histo( ParticleType &_ptype, Resolution &_res ){
+    ptype = _ptype;   
+    res   = _res; 
+  }
+  
+  ~Histo(){ // TODO Had to remove this to avoid seg fault at end of ttbar script. Don't know how to fix.
+    // delete histo;
+  }
+  
+  void perform_slice_fit(Slice &slice, double &beta) {
+    int fit_success = slice.histo->Fit("gaus","QI","",beta*0.95,beta*1.05);
+    if ( fit_success == 0 ) { // Confusingly meaning fit was successful
+      slice.mean  = slice.histo->GetFunction("gaus")->GetParameter(1);
+      slice.sigma = slice.histo->GetFunction("gaus")->GetParameter(2);
+      slice.mean_err  = slice.histo->GetFunction("gaus")->GetParError(1);
+      slice.sigma_err = slice.histo->GetFunction("gaus")->GetParError(2);
+    }
+    
+    fit_success = slice.histo->Fit("gaus","QI","",slice.mean-(2.5*slice.sigma),slice.mean+(2.5*slice.sigma));
+    if ( fit_success == 0 ) {
+      slice.mean      = slice.histo->GetFunction("gaus")->GetParameter(1);
+      slice.sigma     = slice.histo->GetFunction("gaus")->GetParameter(2);
+      slice.mean_err  = slice.histo->GetFunction("gaus")->GetParError(1);
+      slice.sigma_err = slice.histo->GetFunction("gaus")->GetParError(2);
+    }
+  }
+  
+  void slice_histo(int bin_step_size, bool do_fit=true){
+    if (nullptr == histo) {
+      cout << "Can't slice empty histo!" << endl;
+      return;
+    }
+    
+    for (int step_begin=1; step_begin<histo->GetNbinsX()+1; step_begin+=bin_step_size){
+      int step_end = step_begin + bin_step_size - 1;
+      if (step_end > histo->GetNbinsX()) {
+        step_end = histo->GetNbinsX();
+      }
+      int step_center = int(float(step_begin + step_end)/2.0);
+      
+      double p = histo->GetXaxis()->GetBinCenter(step_center);
+      double beta = p/sqrt(ptype.mass*ptype.mass + p*p);
+
+      Slice slice;
+      slice.p = p;
+      TString slice_name = TString( "beta_CH_" + ptype.name_s + "_bin" + to_string(step_center) + "_p" + to_string(p) );
+      slice.histo = histo->ProjectionY(slice_name,step_begin,step_end,"e");
+      slice.histo->SetTitle( TString( "#beta_{CH} sliced at p=" + to_string(p) + "GeV, bin " + to_string(step_center) + ", " + ptype.name_l ) );
+      
+      if (do_fit) {
+        this->perform_slice_fit(slice, beta);
+      }
+      
+      slices.push_back(slice);
+    }
+  }
+  
+  
+};
+typedef vector<Histo> HistoVec;
+typedef vector<shared_ptr<Histo>> HistoPtrVec;
+
+struct HistoMap {
+  HistoPtrVec histos {};
+  
+  HistoMap() {};
+
+  void addHisto( ParticleType &_ptype, Resolution &_res ) {
+    histos.push_back( make_shared<Histo>(_ptype, _res) );
+  }
+  
+  HistoPtrVec getHistosToRes(Resolution &res) const{
+    HistoPtrVec histos_to_res{};
+    for( auto & histo: histos ) {
+      if ( histo->res == res ) { histos_to_res.push_back(histo); }
+    }
+    return histos_to_res;
+  }
+  
+  HistoPtrVec getHistosToPType(ParticleType &ptype) const{
+    HistoPtrVec histos_to_ptype{};
+    for( auto & histo: histos ) {
+      if ( histo->ptype == ptype ) { histos_to_ptype.push_back(histo); }
+    }
+    return histos_to_ptype;
+  }
+  
+  shared_ptr<Histo> getHisto(Resolution &res, ParticleType &ptype) {
+    for ( auto &histo: histos) {
+      if (histo->res == res && histo->ptype == ptype) {
+        return histo;
+      }
+    }
+    return nullptr;
+  }
+};
+
+typedef vector<ParticleType>  ParticleVec; 
+typedef vector<Resolution>    ResVec; 
+typedef vector<Method>        MethodVec;
+typedef vector<float> FloatVec;
+typedef vector<int>   IntVec;
+
+// This is awful...
+// TODO INSTEAD: Add option to add pdg vector to ParticleType
+map<string, IntVec> pdg_map {
+  {"p",   {2212}},
+  {"K",   {130, 310, 311, 321}},
+  {"Pi",  {111, 211}},
+  {"e1",  {11}},
+  {"e2",  {13}}
+};

--- a/TimeOfFlight/macros/reading_config/ReadConfig.py
+++ b/TimeOfFlight/macros/reading_config/ReadConfig.py
@@ -1,0 +1,42 @@
+# Needs to be run with Python3 !
+import configparser # For easy config file handling
+import argparse
+import sys
+import os
+
+#-------------------------------------------------------------------------------
+
+def pwd():
+  '''Like pwd in bash, return path of this file'''
+  return os.path.abspath(os.path.dirname(__file__))
+
+#-------------------------------------------------------------------------------
+
+def main(args):
+  conf_dir = '../../config/'
+  config = configparser.ConfigParser()
+  config.read( pwd() + '/' + conf_dir + args.conf_file )
+  
+  if args.format == 'list_of_keys':
+    print(' '.join(config.sections()))
+  elif args.format == 'single_value':
+    print(config[args.key][args.variables])
+  elif args.format == 'list_of_variables':
+    all_variables = [config[key][args.variables] for key in config.sections()]
+    print(' '.join(all_variables))
+  else: 
+   return    
+
+#-------------------------------------------------------------------------------
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description = 'Config file reader')
+  parser.add_argument('--conf_file',  help='Name of the config file to read')
+  parser.add_argument('--format',     default='list_of_keys',  help='Format of the requested output')
+  parser.add_argument('--key',        nargs='?',  help='Names of the requested keys (to be specified when asking for single value)')
+  parser.add_argument('--variables',  nargs='?',  help='Names of the requested variables')
+  
+  args = parser.parse_args()
+  sys.exit(main(args))
+
+#-------------------------------------------------------------------------------

--- a/TimeOfFlight/macros/reading_config/read_config.cpp
+++ b/TimeOfFlight/macros/reading_config/read_config.cpp
@@ -1,0 +1,106 @@
+struct Section {
+  string key{};
+  map<string,string> variables{};
+  
+  void clear() {
+    key = "";
+    variables = {};
+  }
+  
+  string operator   [](string variable) const  {return variables.at(variable);}
+  string & operator [](string variable)        {return variables[variable];}
+};
+
+class ConfigReader{
+  ofstream config_file {};
+  string file_name {};
+  vector<Section> sections {};
+    
+  int find_key_index (string key) const {
+    int index = 9999;
+    for ( int i=0; i<sections.size(); i++) {
+      if (sections[i].key == key) {
+        index = i;
+        break;
+      }
+    }
+    return index;
+  }  
+    
+  public:
+    ConfigReader( string _file_name ): file_name(_file_name) {
+      this->read_file();
+    }
+    
+    vector<string> get_keys() {
+      vector<string> keys {};
+      for (auto & section: this->sections) { keys.push_back(section.key); }
+      return keys;
+    }
+    
+    Section operator   [](string key) const  {return sections[find_key_index(key)];}
+    Section & operator [](string key)        {return sections[find_key_index(key)];}
+  
+  private:
+    
+    string find_key(string line){
+      string key = "";
+      if (line.find("[") != string::npos) {
+        auto first = line.find("[")+1;
+        auto last = line.find("]");
+        key = line.substr(first,last-first);
+      }
+      return key;
+    }
+    
+    pair<string,string> find_variable(string line){
+      pair<string,string> variable_value {};
+      if (line.find("=") != string::npos) {
+        string line_no_spaces = line;
+        line_no_spaces.erase(remove_if(line_no_spaces.begin(), line_no_spaces.end(), ::isspace), line_no_spaces.end());
+        auto delimiter  = line_no_spaces.find("=");
+        string variable = line_no_spaces.substr(0, delimiter);
+        string value    = line_no_spaces.substr(delimiter+1);
+        variable_value  = make_pair(variable, value);
+      }
+      return variable_value;
+    } 
+    
+    void read_file(){
+      ifstream myfile(file_name.c_str());
+      string line;
+      if (myfile.is_open()) {
+        Section section {};
+        while ( getline (myfile,line) ) {
+          string check_for_key = find_key(line);
+          if (check_for_key != "") {
+            if ( section.key != "" ) { sections.push_back(section); } // Save finished section
+            section.clear();
+            section.key = check_for_key;
+            continue;
+          }
+          auto check_for_variable = find_variable(line);
+          if (check_for_variable.first != "") {
+            section.variables[check_for_variable.first] = check_for_variable.second;
+          }
+        }
+        if ( section.key != "" ) { sections.push_back(section); } // Save last section
+        myfile.close();
+      } else {
+        cout << "ERROR: Unable to open config file!" << endl; 
+      }
+    }
+  
+};
+// 
+// 
+// void read_config() {
+//   string conf_file="../../config/ParticleTypes.cnf";
+//   ConfigReader reader(conf_file);
+//   auto keys = reader.get_keys();
+//   for (auto & key: keys) { 
+//     cout << key << endl;
+//   }
+//   cout << reader["Proton"]["mass"] << endl;
+// 
+// }

--- a/TimeOfFlight/macros/run_singleparticle.sh
+++ b/TimeOfFlight/macros/run_singleparticle.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Read input parameters
+RUN_ON_CONDOR=true
+
+for i in "$@" 
+do
+  case $i in
+    --no-bird)
+    RUN_ON_CONDOR=false
+    ;;
+    *)
+    # Unknown option
+    ;;
+  esac
+done
+
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )" # Directory of this script
+
+run_script="${dir}/creating_lctuples/run_singleparticle_lctuple.sh"
+plotting_script="${dir}/plotting/run_singleparticle_plotting.sh"
+
+chmod u+x ${run_script} ${plotting_script}
+
+filler="*------------------------------------------------------------------------*"
+
+echo "Running Time-Of-Flight script for single particle events."
+echo
+echo "${filler}"
+echo "Creating LCTuple root files."
+echo
+
+if $RUN_ON_CONDOR; then
+  ${run_script}
+else 
+  ${run_script} --no-bird
+fi
+
+echo
+echo "${filler}"
+echo "Running plotting."
+
+${plotting_script}
+
+echo
+echo "${filler}"
+echo "Done with single particle events."
+echo "${filler}"

--- a/TimeOfFlight/macros/submitting_bird_jobs/standard_bash_run.sh
+++ b/TimeOfFlight/macros/submitting_bird_jobs/standard_bash_run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Standard run script that sets up environment and then runs whatever it was given.
+# Purpose: This script can easily be given to HTCondor with any command
+
+if ! [[ $# > 0 ]]; then 
+  echo "usage: ./standard_bash_run.sh command [arguments]"
+  exit
+fi
+
+command_with_arguments=$@
+
+echo "Running command: ${command_with_arguments}"
+eval "${command_with_arguments}" # Execute command

--- a/TimeOfFlight/macros/submitting_bird_jobs/standard_htcondor_steering.submit
+++ b/TimeOfFlight/macros/submitting_bird_jobs/standard_htcondor_steering.submit
@@ -1,0 +1,15 @@
+# simple standard HTCondor submit file with transfer of the executable and usage of the shared filesystem
+# transfer of executable can be handy as you can keep working on the executable locally while the job is running
+# without interference with the binary the job is running
+executable          = standard_bash_run.sh
+transfer_executable = True
+universe            = vanilla
+
+output              = ../../BIRD_output/$(Cluster).$(Process).out
+error               = ../../BIRD_output/$(Cluster).$(Process).error
+log                 = ../../BIRD_output/$(Cluster).$(Process).log
+# _$(Cluster)_$(Process) gets substituted by cluster and process ID, putting it in the output files leads to individual files
+# for each job. Remember that regular filesystem rules about maximum files in a directory and maximum filesizes apply (warning)
+# htcondor will (as any other batchsystem) not create any directories for you, hence these need to exist.
+
+queue

--- a/TimeOfFlight/scripts/template_lctuple_steering_singleparticle.py
+++ b/TimeOfFlight/scripts/template_lctuple_steering_singleparticle.py
@@ -1,0 +1,61 @@
+<!--##########################################
+    #     Steering file template for marlin  #
+    #     writes an LCTuple with PandoraPFOs #
+    #     and TOF parameters                 #
+    ##########################################-->
+
+
+<marlin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ilcsoft.desy.de/marlin/marlin.xsd">
+ <execute>
+  <processor name="MyAIDAProcessor"/>
+  <processor name="MyLCTuple"/>  
+ </execute>
+
+ <global>
+  <parameter name="LCIOInputFiles">    
+    {INPUT_FILES}  
+  </parameter>
+  <!-- limit the number of processed records (run+evt): -->  
+  <parameter name="MaxRecordNumber" value="0" />  
+  <parameter name="SkipNEvents" value="0"/>  
+  <parameter name="SupressCheck" value="false" />  
+  <!-- <parameter name="GearXMLFile"></parameter>   -->
+  <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT">ERROR  </parameter> 
+  <parameter name="RandomSeed" value="1234567890" />
+ </global>
+
+  <processor name="MyAIDAProcessor" type="AIDAProcessor">
+    <parameter name="FileName" type="string">
+      {OUTPUT_FILE_BASE} 
+    </parameter> 
+    <parameter name="FileType" type="string">root </parameter>
+  </processor>
+  <!-- lctuplePi lctuplep lctupleK lctuplee1 lctuplee2-->
+
+  <processor name="MyLCTuple" type="LCTuple">
+    <!--LCTuple creates a ROOT TTRee with a column wise ntuple from LCIO collections ....-->
+    
+    <!--Name of the ReconstructedParticle collection-->
+    <parameter name="RecoParticleCollection" type="string" lcioInType="ReconstructedParticle"> PandoraPFOs </parameter>
+    <parameter name="LCRelationWithPFOCollections" type="string" lcioInType="LCRelation"> RecoMCTruthLink </parameter>
+    <!--Names of LCRelation collections - need parallel prefix names in RelPrefixes-->
+    <parameter name="LCRelationCollections" type="StringVec" lcioInType="LCRelation">
+      RecoMCTruthLink 
+    </parameter>
+    
+    <!-- Names of prefixes for variables from LCRelation collections - needs to be parallel to LCRelationCollections (one prefix per collection)-->
+    <parameter name="LCRelationPrefixes" type="StringVec">  
+      r2m  
+    </parameter>
+    <!--Name of the MCParticle collection-->
+    <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle"> MCParticle</parameter>
+    <!--Definition of PID branches added to the ReconstructedParticle branches - for every algorithm:
+    Algorithm:Name branchPrefix Parameter0 branch0  Parameter1 branch1  Parameter2 branch2 ...-->
+    <parameter name="PIDBranchDefinition" type="StringVec">
+      {TOF_PID_BRANCHES}
+    </parameter>
+    
+    <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+    <!-- <parameter name="Verbosity" type="string">DEBUG </parameter> -->
+  </processor>
+</marlin>

--- a/TimeOfFlight/scripts/template_lctuple_steering_ttbar.py
+++ b/TimeOfFlight/scripts/template_lctuple_steering_ttbar.py
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<!-- ?xml-stylesheet type="text/xsl" href="http://ilcsoft.desy.de/marlin/marlin.xsl"? -->
+<!-- ?xml-stylesheet type="text/xsl" href="marlin.xsl"? -->
+
+<!-- Loading shared library : /Users/fgaede/marlin/mymarlin/lib/libmymarlin.0.1.0.dylib (libmymarlin.dylib)-->
+
+<!--##########################################
+    #                                        #
+    #     Example steering file for marlin   #
+    #     writes an LCTuple with PandoraPFOs #
+    #     and TOF parameters                 #
+    ##########################################-->
+
+
+<marlin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ilcsoft.desy.de/marlin/marlin.xsd">
+ <execute>
+  <processor name="MyAIDAProcessor"/>
+  <processor name="TOFEstimators0ps"/>
+  <processor name="TOFEstimators10ps"/>
+  <processor name="TOFEstimators50ps"/> 
+  <processor name="MyLCTuple"/>  
+ </execute>
+
+ <global>
+  <parameter name="LCIOInputFiles">    
+    
+  </parameter>
+ 
+
+  <!-- limit the number of processed records (run+evt): -->  
+  <parameter name="MaxRecordNumber" value="0" />  
+  <parameter name="SkipNEvents" value="0"/>  
+  <parameter name="SupressCheck" value="false" />  
+  <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT">ERROR  </parameter> 
+  <parameter name="RandomSeed" value="1234567890" />
+ </global>
+
+
+
+ <processor name="MyAIDAProcessor" type="AIDAProcessor">
+  <parameter name="FileName" type="string">lctuplettbar </parameter> 
+  <parameter name="FileType" type="string">root </parameter>
+ </processor>
+ <!-- lctuplePi lctuplep lctupleK lctuplee1 lctuplee2-->
+
+
+
+ <processor name="MyLCTuple" type="LCTuple">
+ <!--LCTuple creates a ROOT TTRee with a column wise ntuple from LCIO collections ....-->
+
+ <!--Name of the ReconstructedParticle collection-->
+  <parameter name="RecoParticleCollection" type="string" lcioInType="ReconstructedParticle"> PandoraPFOs </parameter>
+  <parameter name="LCRelationWithPFOCollections" type="string" lcioInType="LCRelation"> RecoMCTruthLink </parameter>
+  <!--Names of LCRelation collections - need parallel prefix names in RelPrefixes-->
+  <parameter name="LCRelationCollections" type="StringVec" lcioInType="LCRelation">
+    RecoMCTruthLink 
+   </parameter>
+  
+  <!-- Names of prefixes for variables from LCRelation collections - needs to be parallel to LCRelationCollections (one prefix per collection)-->
+  <parameter name="LCRelationPrefixes" type="StringVec">  
+    r2m  
+  
+  </parameter>
+  <!--Name of the MCParticle collection-->
+  <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle"> MCParticle</parameter>
+
+
+ <!--########## add TOF estimators for 100, 200 and 300 ps resolution  ###################################### -->
+
+ 
+  <!--Definition of PID branches added to the ReconstructedParticle branches - for every algorithm:
+      Algorithm:Name branchPrefix Parameter0 branch0  Parameter1 branch1  Parameter2 branch2 ...-->
+  <parameter name="PIDBranchDefinition" type="StringVec">
+    Algorithm:TOFEstimators0ps tof0
+    TOFFirstHit TOFClosestHits TOFClosestHitsError TOFFlightLength TOFLastTrkHit TOFLastTrkHitFlightLength
+    fh          ch             che                 len             th            thl
+    Algorithm:TOFEstimators10ps tof10
+    TOFFirstHit TOFClosestHits TOFClosestHitsError TOFFlightLength TOFLastTrkHit TOFLastTrkHitFlightLength
+    fh          ch             che                 len             th            thl
+    Algorithm:TOFEstimators50ps tof50
+    TOFFirstHit TOFClosestHits TOFClosestHitsError TOFFlightLength TOFLastTrkHit TOFLastTrkHitFlightLength
+    fh          ch             che                 len             th            thl
+  </parameter>
+  <!-- Algorithm:TOFEstimators100ps tof100
+  TOFFirstHit TOFClosestHits TOFClosestHitsError TOFFlightLength TOFLastTrkHit TOFLastTrkHitFlightLength
+  fh          ch             che                 len             th            thl
+  Algorithm:TOFEstimators200ps tof200
+  TOFFirstHit TOFClosestHits TOFClosestHitsError TOFFlightLength TOFLastTrkHit TOFLastTrkHitFlightLength
+  fh          ch             che                 len             th            thl
+  Algorithm:TOFEstimators300ps tof300
+  TOFFirstHit TOFClosestHits TOFClosestHitsError TOFFlightLength TOFLastTrkHit TOFLastTrkHitFlightLength
+  fh          ch             che                 len             th            thl -->
+  
+  <!-- can also add other PID algorithms, eg: 
+    Algorithm:dEdxPID dedx
+    electronLikelihood muonLikelihood  pionLikelihood kaonLikelihood protonLikelihood hadronLikelihood
+    lhe                lhmu            lhpi           lhk            lhp              lhhad
+
+   -->
+
+
+
+
+
+  <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+  <!-- <parameter name="Verbosity" type="string">DEBUG </parameter> -->
+</processor>
+
+ <processor name="TOFEstimators0ps" type="TOFEstimators">
+    <!--TOFEstimators compute some estimators for the time of flight from calorimeter hits-->
+    <!--Use only calorimeter hits up to MaxLayerNumber in TOF estimators-->
+    <parameter name="MaxLayerNumber" type="int">10 </parameter>
+    <!--Name of the ReconstructedParticle collection-->
+    <parameter name="ReconstructedParticleCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
+    <!--Assumed time resolution per hit in ps-->
+    <parameter name="TimeResolution" type="float">0 </parameter>
+  </processor>
+  <processor name="TOFEstimators10ps" type="TOFEstimators">
+    <!--TOFEstimators compute some estimators for the time of flight from calorimeter hits-->
+    <!--Use only calorimeter hits up to MaxLayerNumber in TOF estimators-->
+    <parameter name="MaxLayerNumber" type="int">10 </parameter>
+    <!--Name of the ReconstructedParticle collection-->
+    <parameter name="ReconstructedParticleCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
+    <!--Assumed time resolution per hit in ps-->
+    <parameter name="TimeResolution" type="float">10 </parameter>
+  </processor>
+  <processor name="TOFEstimators50ps" type="TOFEstimators">
+    <!--TOFEstimators compute some estimators for the time of flight from calorimeter hits-->
+    <!--Use only calorimeter hits up to MaxLayerNumber in TOF estimators-->
+    <parameter name="MaxLayerNumber" type="int">10 </parameter>
+    <!--Name of the ReconstructedParticle collection-->
+    <parameter name="ReconstructedParticleCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs </parameter>
+    <!--Assumed time resolution per hit in ps-->
+    <parameter name="TimeResolution" type="float">50 </parameter>
+    </processor>
+
+</marlin>

--- a/WWZZSeparation/plotting/create_mjjmjjplots.cc
+++ b/WWZZSeparation/plotting/create_mjjmjjplots.cc
@@ -157,6 +157,18 @@ void create_mjjmjjplots(
   string plot_name_h2 = input_dir_base + "/m_m.pdf";
   canvas_h2->Print(plot_name_h2.c_str());
 
+  // Save plots to root file too
+  string plot_file_name = input_dir_base + "/m_plots.root";
+  TFile *plot_file = new TFile(plot_file_name.c_str(), "recreate");
+
+  h1_WW->Write();
+  h1_ZZ->Write();
+  h2_WW->Write();
+  h2_ZZ->Write();
+
+  plot_file->Close();
+  delete plot_file;
+
   // Avoid memory leaks
   delete h1_WW;
   delete h2_WW;

--- a/WWZZSeparation/scripts/run_plotting.sh
+++ b/WWZZSeparation/scripts/run_plotting.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-DETECTOR_MODEL=ILCSoft-01-19-06_gcc49_ILDConfig_v01-19-06-p01 
-
 for i in "$@"
 do
 case $i in


### PR DESCRIPTION
BEGINRELEASENOTES

- Add scripts to create TOF-separation plots for single particles (based on Sukees code), including config files for steering.
- In WWZZSeparation: Remove legacy parameter in plotting script and save TH1s in plotting macro.

ENDRELEASENOTES