### PR TITLE
add missing #include <unistd.h> for c++17

### DIFF
--- a/dEdX/main/dEdxHistPlotter.cc
+++ b/dEdX/main/dEdxHistPlotter.cc
@@ -3,6 +3,7 @@
 #include <string>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include "TFile.h"
 #include "TDirectory.h"


### PR DESCRIPTION

BEGINRELEASENOTES
- make compatible w/ -std=c++17
      - needed on macos w/ clang

ENDRELEASENOTES