### PR TITLE
dEdx1.2

### DIFF
--- a/dEdX/Readme.md
+++ b/dEdX/Readme.md
@@ -2,7 +2,7 @@
 
 Performance plots for dE/dx.
 
-- U. Einhaus, Mar 2021
+- U. Einhaus, Apr 2021, v1.2
 
 ## Overview
 
@@ -20,7 +20,7 @@ The required collections are Tracks, a TrackMCTruthLink and the corresponding MC
 If tracks attached to PFOs should be used, also a PFO collection is required.
 The number of particle species to be investigated and their properties are hard-coded and must be set:
 *_nPart* is the number of species, set in this header, while the PDG number and the names of the particles (for labeling the histograms) are set in the init().
-default: *_nPart* = 5; species: electrons, muons, pions, kaon, protons.
+This version: *_nPart* = 5; species: electrons, muons, pions, kaon, protons.
 
 First, in processEvent(), the dE/dx values of each track is filled in the corresponding histogram, resulting in Bethe-Bloch curves.
 The correct PDG is received from the MCParticle linked to the track.
@@ -29,30 +29,47 @@ The separation power is calculated for each combination of the *_nPart* species.
 All histograms, including the auto-generated fit results, are stored via AIDA in a root file.
 Finally, many of the histograms can be plotted and saved as images to the current working directory.
 
+Several special histograms for calibration purposes are provided.
+The FiducialElectrons histograms collects electrons which are similar to electrons at the test beam. The resulting dE/dx resolution in ResNorm_FiducialElectrons should be used to calibrate the smearing factor in the Compute_dEdxProcessor.
+The histogram NormLambdaFullAll_1 contains the mean dE/dx over |lambda| incl. a poly3 fit, which is used in the AngularCorrection_dEdxProcessor for correction of the angular dependence.
+The histogram NormCosThFullAll_1 contains the mean dE/dx over cos(theta), and shows the information of NormLambdaFullAll_1 over an alternative angular scale.
+The Bethe-Bloch curves in BBHist are fitted to provide the parameters of the reference curves for the dEdxPID in the LikelihoodPIDProcessor.
+The fit results are stored with the histograms and also printed on the console at the end of the processor.
+
+You can run this Analyser over any selection of tracks, e. g. only pion and kaon tracks.
+In that case, only the pion and kaon resolution as well as only the pion-kaon separation would give sensible plots, but all other plots would be generated empty alongside.
+The Analyser has mostly been used to extract the dE/dx performance from single-particle random-momentum files, but also to check e. g. 6f-ttbar events.
+
+Note that the hit energy histograms will only be filled, if the track hits are available, which is usually only the case for REC-files.
+The hit number histograms are unaffected by this.
+
 General processor parameters:
 
 - **plotStuff** - Set to true to switch on automatic image generation of many histograms in the current working directory.
   bool, default: false.
 - **fileFormat** - Select the file extension to be used for the automatically generated images.
+  Selection depends on root TPad::Print() capabilities, typically: [.ps, .eps, .pdf, .svg, .tex, .gif, .xpm, .png, .jpg, .tiff, .cxx, .xml, .json, .root].
+  See https://root.cern.ch/doc/master/classTPad.html#ad2fc5f449e4cb5480b9fb05fda3a8307 for details.
   string, default: .png
+
 - **usePFOTracks** - Set to true to use tracks attached to charged PFO, instead of all tracks in the track collection. This should be used with events which are more busy than single particle files.
+  bool, default: false.
+- **useOneTrack** - Set true if from every event only the first object in the selected collection (track or PFO) should be used. Usually, don't combine this with _usePFOTracks.
   bool, default: false.
 
 You can make a track selection via the optional parameters, e. g. to reduce 'contamination' from mis-linked Tracks and MCParticles.
 
-- **useOneTrack** - Set true if from every event only the first track should be used.
-  bool, default: false.
 - **cutdEdx** - Set true if particles with a very off dE/dx value (hard-coded) should be ignored.
   bool, default: false.
 - **cutTrackPurity** - Set true if particles should be ignored, where the MCParticle is connected to more than one track.
   bool, default: false.
-- **cutD0** - Tracks with a d0 larger than the given value should be ignored. Set to 0 to accept all particles.
+- **cutD0** - Tracks with a d0 larger than the given value will be ignored. Set to 0 to accept all particles.
   double, default: 0.
-- **cutZ0** - Tracks with a z0 larger than the given value should be ignored. Set to 0 to accept all particles.
+- **cutZ0** - Tracks with a z0 larger than the given value will be ignored. Set to 0 to accept all particles.
   double, default: 0.
-- **cutMomMin** - Tracks with a momentum smaller than the given value should be ignored. Set to 0 to accept all particles.
+- **cutMomMin** - Tracks with a momentum smaller than the given value will be ignored. Set to 0 to accept all particles.
   double, default: 0.
-- **cutMomMax** - Tracks with a momentum larger than the given value should be ignored. Set to 0 to accept all particles.
+- **cutMomMax** - Tracks with a momentum larger than the given value will be ignored. Set to 0 to accept all particles.
   double, default: 0.
  
 For calibration with beam test results, so-called fiducial electrons are selected, which ought to be similar to beam-test conditions, and their properties stored in separate histograms.
@@ -83,12 +100,6 @@ For some of the histograms, the axis binning can be adapted, which can be useful
 - **maxBinY** - Upper end of the dE/dx axis in GeV/mm in histograms.
   double, default: 1e-6.
 
-You can run this Analyser over any selection of tracks, e. g. only pion and kaon tracks.
-In that case, only the pion and kaon resolution as well as only the pion-kaon separation would give sensible plots, but all other plots would be generated empty alongside.
-The Analyser has mostly been used to extract the dE/dx performance from single-particle random-momentum files, but also to check e. g. 6f-ttbar events.
-
-Note that the hit energy histograms will only be filled, if the track hits are available, which is usually only the case for REC-files.
-The hit number histograms are unaffected by this.
 
 ## dEdxHistPlotter
 


### PR DESCRIPTION

BEGINRELEASENOTES
Update of the dEdxAnalyser to v1.2 with new features for calibration:
- fit poly3 to mean dE/dx vs. |lambda| -> input to AngularCorrection_dEdxProcessor
- fit Bethe-Bloch curves mean dE/dx values -> input to LikelihoodPIDProcessor
- these two fits and the fiducial electrons dE/dx resolution are printed on the console at the end of the Analyser

ENDRELEASENOTES