### PR TITLE
fix memory leak in PIDTree

### DIFF
--- a/PID/src/PIDTree.cc
+++ b/PID/src/PIDTree.cc
@@ -385,13 +385,13 @@ void PIDTree::processEvent( LCEvent * evt ) {
 
       // Particle IDs
         LCCollection* rpcol = evt->getCollection( _pandoraPFOs ) ;
-        PIDHandler *pidh = new PIDHandler(rpcol);
+        PIDHandler pidh(rpcol);
 
-        basicPDG.push_back(pidh->getParticleID(rcp, pidh->getAlgorithmID("BasicVariablePID")).getPDG());
-        dEdxPDG.push_back(pidh->getParticleID(rcp, pidh->getAlgorithmID("dEdxPID")).getPDG());
-        showerPDG.push_back(pidh->getParticleID(rcp, pidh->getAlgorithmID("ShowerShapesPID")).getPDG());
-        likeliPDG.push_back(pidh->getParticleID(rcp, pidh->getAlgorithmID("LikelihoodPID")).getPDG());
-        lowmomPDG.push_back(pidh->getParticleID(rcp, pidh->getAlgorithmID("LowMomMuID")).getPDG());
+        basicPDG.push_back(pidh.getParticleID(rcp, pidh.getAlgorithmID("BasicVariablePID")).getPDG());
+        dEdxPDG.push_back(pidh.getParticleID(rcp, pidh.getAlgorithmID("dEdxPID")).getPDG());
+        showerPDG.push_back(pidh.getParticleID(rcp, pidh.getAlgorithmID("ShowerShapesPID")).getPDG());
+        likeliPDG.push_back(pidh.getParticleID(rcp, pidh.getAlgorithmID("LikelihoodPID")).getPDG());
+        lowmomPDG.push_back(pidh.getParticleID(rcp, pidh.getAlgorithmID("LowMomMuID")).getPDG());
 
 
 // JL July 25, 2016 : ParticleIDVec does not seem to get filled !!!
@@ -436,7 +436,7 @@ void PIDTree::processEvent( LCEvent * evt ) {
 //         }
 
 
-        const ParticleID* likeliPID = &(pidh->getParticleID(rcp, pidh->getAlgorithmID("LikelihoodPID")));
+        const ParticleID* likeliPID = &(pidh.getParticleID(rcp, pidh.getAlgorithmID("LikelihoodPID")));
         float likelihood[5] = {999.,999.,999.,999.,999};
         if (likeliPID && likeliPID->getParameters().size() > 4 ) {
           for ( int ihyp = 0 ; ihyp < 5; ihyp++ ) {
@@ -461,7 +461,7 @@ void PIDTree::processEvent( LCEvent * evt ) {
         LiPDG_ka.push_back(likelihood[3]);
         LiPDG_pr.push_back(likelihood[4]);
 
-        const ParticleID* dedxPID = &(pidh->getParticleID(rcp, pidh->getAlgorithmID("dEdxPID")));
+        const ParticleID* dedxPID = &(pidh.getParticleID(rcp, pidh.getAlgorithmID("dEdxPID")));
         float dedxlikeli[5] = {999.,999.,999.,999.,999.};
         float distance[5] = {999.,999.,999.,999.,999.};
         if (dedxPID && dedxPID->getParameters().size() > 17 ) {
@@ -475,7 +475,7 @@ void PIDTree::processEvent( LCEvent * evt ) {
             if ( std::isinf(distance[ihyp]) ) {
               distance[ihyp] = 888.;
             }
-            streamlog_out(DEBUG3) << pidh->getParameterNames(pidh->getAlgorithmID("dEdxPID"))[13+ihyp] << " = " << distance[ihyp] << std::endl;
+            streamlog_out(DEBUG3) << pidh.getParameterNames(pidh.getAlgorithmID("dEdxPID"))[13+ihyp] << " = " << distance[ihyp] << std::endl;
           }
           streamlog_out(DEBUG) << " dEdx liklihood electron hyp = " << dedxlikeli[0] << std::endl;
           streamlog_out(DEBUG) << " dEdx liklihood muon hyp = "     << dedxlikeli[1] << std::endl;

--- a/PID/src/PIDTree.cc
+++ b/PID/src/PIDTree.cc
@@ -15,73 +15,73 @@ using namespace lcio ;
 //using namespace std ;
 
 PIDTree::PIDTree() : Processor("PIDTree") {
-  
+
   // modify processor description
   _description = "PIDTree create a ROOT TTree with PID parameters" ;
 
-  
+
   // register steering parameters: name, description, class-variable, default value
 
 
   registerInputCollection( LCIO::LCRELATION,
-			   "MCTruth2RecoLinkCollectionName" , 
+			   "MCTruth2RecoLinkCollectionName" ,
 			   "true - reco relation collection"  ,
 			   _trueToReco,
 			   std::string("MCTruthRecoLink") ) ;
 
 
   registerInputCollection( LCIO::LCRELATION,
-			   "Reco2MCTruthLinkCollectionName" , 
+			   "Reco2MCTruthLinkCollectionName" ,
 			   "reco - true relation collection"  ,
 			   _recoToTrue,
 			   std::string("RecoMCTruthLink") ) ;
 
 
   registerInputCollection( LCIO::LCRELATION,
-			   "MCTruth2TrackLinkCollectionName" , 
+			   "MCTruth2TrackLinkCollectionName" ,
 			   "true - track relation collection"  ,
 			   _trueToTrack,
 			   std::string("MCTruthMarlinTrkTracksLink") ) ;
 
 
   registerInputCollection( LCIO::MCPARTICLE,
-			   "MCParticleCollection" , 
+			   "MCParticleCollection" ,
 			   "Name of the MCParticle input collection"  ,
 			   _mcParticleCollectionName ,
 			   std::string("MCParticle") ) ;
 
 
   registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-			   "BCALParticles" , 
+			   "BCALParticles" ,
 			   "Name of the BCALParticles input collection"  ,
 			   _BCALParticleCollectionName ,
 			   std::string("BCALParticles") ) ;
 
   registerInputCollection( LCIO::CLUSTER,
-			   "BCALCLusters" , 
+			   "BCALCLusters" ,
 			   "Name of the BCAL clusters input collection"  ,
 			   _BCALClusterCollectionName ,
 			   std::string("BCALCLusters") ) ;
 
 
   registerInputCollection( LCIO::RECONSTRUCTEDPARTICLE,
-                            "PFOs" , 
+                            "PFOs" ,
                             "particle flow objects"  ,
                             _pandoraPFOs ,
                             std::string("PandoraPFOs") ) ;
- 
+
   registerInputCollection( LCIO::TRACK,
-			   "StudiedTracks" , 
+			   "StudiedTracks" ,
 			   "Name of the FullLDC track collection"  ,
 			   _trackColName ,
-			   std::string("MarlinTrkTracks") ) ;  
+			   std::string("MarlinTrkTracks") ) ;
 
 }
 
 
-void PIDTree::init() { 
+void PIDTree::init() {
 
-  streamlog_out(DEBUG) << "   init called  " 
+  streamlog_out(DEBUG) << "   init called  "
 		       << std::endl ;
 
   // usually a good idea tomcp->getPDG()
@@ -91,15 +91,15 @@ void PIDTree::init() {
   gROOT->ProcessLine("#include <vector>");
 }
 
-void PIDTree::processRunHeader( LCRunHeader*) { 
-    
-} 
+void PIDTree::processRunHeader( LCRunHeader*) {
 
-void PIDTree::processEvent( LCEvent * evt ) { 
+}
+
+void PIDTree::processEvent( LCEvent * evt ) {
 
   streamlog_out(DEBUG3)  << "=================================  start processing event " << nEvt << std::endl ;
 
-  if( isFirstEvent() ) { 
+  if( isFirstEvent() ) {
     hermTree = new TTree("hermTree","hermTree");
     hermTree->Branch("nMCParticles",&nMCParticles,"nMCParticles/I") ;
     hermTree->Branch("trueP",&trueP) ;
@@ -142,87 +142,87 @@ void PIDTree::processEvent( LCEvent * evt ) {
     hermTree->Branch("dedxPDG_pr",&dedxPDG_pr) ;
 
   }
-  
+
   streamlog_out(DEBUG) << " clearing vectors " << std::endl;
   nMCParticles = 0;
-  trueP.clear();  
-  trueMass.clear();  
-  truePt.clear();  
-  trueTheta.clear();  
-  truePhi.clear();  
-  trueCharge.clear();  
-  truePDG.clear();  
-  trueMother.clear();  
-  isTrue.clear();  
-  isSeen.clear();  
-  isSeenDEdx.clear();  
-  seenP.clear();  
-  seenPt.clear();  
-  seenTheta.clear();  
-  seenPhi.clear();  
-  seenDEdx.clear();  
-  seenDEdxErr.clear();  
-  seenCharge.clear();  
-  basicPDG.clear();  
-  dEdxPDG.clear();  
-  showerPDG.clear();  
-  likeliPDG.clear();  
-  lowmomPDG.clear(); 
-  LiPDG_el.clear(); 
-  LiPDG_mu.clear(); 
-  LiPDG_pi.clear(); 
-  LiPDG_ka.clear(); 
-  LiPDG_pr.clear();  
-  dedxdist_el.clear(); 
-  dedxdist_mu.clear(); 
-  dedxdist_pi.clear(); 
-  dedxdist_ka.clear(); 
-  dedxdist_pr.clear();  
-  dedxPDG_el.clear(); 
-  dedxPDG_mu.clear(); 
-  dedxPDG_pi.clear(); 
-  dedxPDG_ka.clear(); 
-  dedxPDG_pr.clear();  
+  trueP.clear();
+  trueMass.clear();
+  truePt.clear();
+  trueTheta.clear();
+  truePhi.clear();
+  trueCharge.clear();
+  truePDG.clear();
+  trueMother.clear();
+  isTrue.clear();
+  isSeen.clear();
+  isSeenDEdx.clear();
+  seenP.clear();
+  seenPt.clear();
+  seenTheta.clear();
+  seenPhi.clear();
+  seenDEdx.clear();
+  seenDEdxErr.clear();
+  seenCharge.clear();
+  basicPDG.clear();
+  dEdxPDG.clear();
+  showerPDG.clear();
+  likeliPDG.clear();
+  lowmomPDG.clear();
+  LiPDG_el.clear();
+  LiPDG_mu.clear();
+  LiPDG_pi.clear();
+  LiPDG_ka.clear();
+  LiPDG_pr.clear();
+  dedxdist_el.clear();
+  dedxdist_mu.clear();
+  dedxdist_pi.clear();
+  dedxdist_ka.clear();
+  dedxdist_pr.clear();
+  dedxPDG_el.clear();
+  dedxPDG_mu.clear();
+  dedxPDG_pi.clear();
+  dedxPDG_ka.clear();
+  dedxPDG_pr.clear();
 
   streamlog_out(DEBUG) << " iterator and navigator " << std::endl;
   LCIterator<MCParticle> mcpIt( evt, _mcParticleCollectionName ) ;
   streamlog_out(DEBUG) << " got mcpIt " << mcpIt.size() << std::endl;
-  LCRelationNavigator mc2recoNav(evt->getCollection( _trueToReco )); 
+  LCRelationNavigator mc2recoNav(evt->getCollection( _trueToReco ));
   streamlog_out(DEBUG) << " got mc2recoNav from " << mc2recoNav.getFromType() << " to " << mc2recoNav.getToType() << std::endl;
-  LCRelationNavigator reco2mcNav(evt->getCollection( _recoToTrue )); 
+  LCRelationNavigator reco2mcNav(evt->getCollection( _recoToTrue ));
   streamlog_out(DEBUG) << " got reco2mcNav from " << reco2mcNav.getFromType() << " to " << reco2mcNav.getToType() << std::endl;
-  LCRelationNavigator mc2trackNav(evt->getCollection( _trueToTrack )); 
+  LCRelationNavigator mc2trackNav(evt->getCollection( _trueToTrack ));
   streamlog_out(DEBUG) << " got mc2trackNav from " << mc2trackNav.getFromType() << " to " << mc2trackNav.getToType() << std::endl;
-  
+
   //----------------------------------------------------------------------------------------------------------------------------
   // loop over MCParticles
   //----------------------------------------------------------------------------------------------------------------------------
-  
+
   int imcp = -1;
   while( MCParticle* mcp = mcpIt.next()  ) {
-    
-    if (!mcp) continue; 
-    
+
+    if (!mcp) continue;
+
     imcp++;
     if (mcp->getGeneratorStatus() == 1) {
-      streamlog_out(DEBUG3) << "=========================================================================================" << std::endl;  
+      streamlog_out(DEBUG3) << "=========================================================================================" << std::endl;
     }
-    streamlog_out(DEBUG3) << " mcparticle " << imcp << " has PDG = " << mcp->getPDG() << " and genstat = " << mcp->getGeneratorStatus() << std::endl;  
-    
+    streamlog_out(DEBUG3) << " mcparticle " << imcp << " has PDG = " << mcp->getPDG() << " and genstat = " << mcp->getGeneratorStatus() << std::endl;
+
     bool keep = false;
-    // keep stable generator particles 
+    // keep stable generator particles
     // make something more sophisticated here later!
-    if (mcp->getGeneratorStatus() == 1) keep = true; 
-    
-    if (keep) {   
-    
+    if (mcp->getGeneratorStatus() == 1) keep = true;
+
+    if (keep) {
+
       nMCParticles++;
-    
+
       dd4hep::rec::Vector3D v( mcp->getVertex()[0], mcp->getVertex()[1], mcp->getVertex()[2] );
       dd4hep::rec::Vector3D e( mcp->getEndpoint()[0], mcp->getEndpoint()[1], mcp->getEndpoint()[2] );
       dd4hep::rec::Vector3D p( mcp->getMomentum()[0], mcp->getMomentum()[1], mcp->getMomentum()[2] );
-    
-      streamlog_out(DEBUG) << " start push_back " << std::endl;  
+
+      streamlog_out(DEBUG) << " start push_back " << std::endl;
       trueP.push_back(p.r());
       trueMass.push_back( mcp->getMass() ) ;
       truePt.push_back(p.trans());
@@ -230,19 +230,19 @@ void PIDTree::processEvent( LCEvent * evt ) {
       truePhi.push_back(p.phi());
       trueCharge.push_back(mcp->getCharge());
       truePDG.push_back(mcp->getPDG());
-      streamlog_out(DEBUG) << " before getting parent " << std::endl;  
+      streamlog_out(DEBUG) << " before getting parent " << std::endl;
       if ( mcp->getParents().size() > 0 ) {
         trueMother.push_back(mcp->getParents()[0]->getPDG());
-      }  
+      }
       else {
         trueMother.push_back(-1);
       }
-    
-      streamlog_out(DEBUG) << " get reco particle " << std::endl;  
+
+      streamlog_out(DEBUG) << " get reco particle " << std::endl;
       const EVENT::LCObjectVec& recovec = mc2recoNav.getRelatedToObjects(mcp);
-      streamlog_out(DEBUG3) << " recovec has length " << recovec.size() << std::endl;  
+      streamlog_out(DEBUG3) << " recovec has length " << recovec.size() << std::endl;
       const EVENT::FloatVec& recoweightvec = mc2recoNav.getRelatedToWeights(mcp);
-      streamlog_out(DEBUG) << " recoweightvec has length " << recoweightvec.size() << std::endl;  
+      streamlog_out(DEBUG) << " recoweightvec has length " << recoweightvec.size() << std::endl;
       double maxtrckweight = 0;
       double maxcaloweight = 0;
       int imaxtrckweight = -1;
@@ -251,9 +251,9 @@ void PIDTree::processEvent( LCEvent * evt ) {
       for (unsigned int irel = 0; irel < recovec.size(); irel++) {
         trckweight = double((int(recoweightvec.at(irel))%10000)/1000.);
         caloweight = double((int(recoweightvec.at(irel))/10000)/1000.);
-        streamlog_out(DEBUG3) << " irel " << irel << ", recoweight = " << int(recoweightvec.at(irel)) 
+        streamlog_out(DEBUG3) << " irel " << irel << ", recoweight = " << int(recoweightvec.at(irel))
                              << ", recoweight%10000 = " << trckweight
-                             << ", recoweight/10000 = " << caloweight << std::endl;  
+                             << ", recoweight/10000 = " << caloweight << std::endl;
         if (trckweight > maxtrckweight) {
           imaxtrckweight = irel;
           maxtrckweight = trckweight;
@@ -263,63 +263,63 @@ void PIDTree::processEvent( LCEvent * evt ) {
           maxcaloweight = caloweight;
         }
       }
-      
+
       streamlog_out(DEBUG3) << " found reco particle for mcp at imaxtrackweight = " << imaxtrckweight << " with weight = " << maxtrckweight << std::endl ;
       streamlog_out(DEBUG3) << " found reco particle for mcp at imaxcaloweight = " << imaxcaloweight << " with weight = " << maxcaloweight << std::endl ;
-      
-      
+
+
       // NOW check backwards relation as well:
-      // catch cases where a PFO fully contains the MCP, but the MCP is only a small contribution to the PFO                     
-      
+      // catch cases where a PFO fully contains the MCP, but the MCP is only a small contribution to the PFO
+
       double mcptrckweight = -1;
       if ( imaxtrckweight > -1 && imaxtrckweight < (int)recovec.size() ) {
-        ReconstructedParticle* rcptrck =  (ReconstructedParticle*) recovec.at(imaxtrckweight); 
-        streamlog_out(DEBUG3) << " get MC particle for track " << std::endl;  
+        ReconstructedParticle* rcptrck =  (ReconstructedParticle*) recovec.at(imaxtrckweight);
+        streamlog_out(DEBUG3) << " get MC particle for track " << std::endl;
         const EVENT::LCObjectVec& mcptrckvec = reco2mcNav.getRelatedToObjects(rcptrck);
-        streamlog_out(DEBUG3) << " mcptrckvec has length " << mcptrckvec.size() << std::endl;  
+        streamlog_out(DEBUG3) << " mcptrckvec has length " << mcptrckvec.size() << std::endl;
         const EVENT::FloatVec& mcptrckweightvec = reco2mcNav.getRelatedToWeights(rcptrck);
-        streamlog_out(DEBUG3) << " mcptrckweightvec has length " << mcptrckweightvec.size() << std::endl; 
-      
+        streamlog_out(DEBUG3) << " mcptrckweightvec has length " << mcptrckweightvec.size() << std::endl;
+
         // check whether track vector contains original MCP
         for (unsigned imcptrck = 0; imcptrck < mcptrckvec.size(); imcptrck++ ) {
-          if ( mcptrckvec.at(imcptrck) == mcp ) { 
+          if ( mcptrckvec.at(imcptrck) == mcp ) {
             mcptrckweight = double((int(mcptrckweightvec.at(imcptrck))%10000)/1000.);
-            streamlog_out(DEBUG3) << " found original MCP in mcptrckvec at position " << imcptrck << " with weight " << mcptrckweight << std::endl; 
-          } 
+            streamlog_out(DEBUG3) << " found original MCP in mcptrckvec at position " << imcptrck << " with weight " << mcptrckweight << std::endl;
+          }
         }
-      }  
-      else {
-        streamlog_out(DEBUG3) << " imaxtrckweight out of range, skipping backwards check " << std::endl;  
       }
-      
+      else {
+        streamlog_out(DEBUG3) << " imaxtrckweight out of range, skipping backwards check " << std::endl;
+      }
+
       double mcpcaloweight = -1;
       if ( imaxcaloweight > -1 && imaxcaloweight < (int)recovec.size() ) {
-        ReconstructedParticle* rcpcalo =  (ReconstructedParticle*) recovec.at(imaxcaloweight); 
-        streamlog_out(DEBUG3) << " get MC particle for cluster " << std::endl;  
+        ReconstructedParticle* rcpcalo =  (ReconstructedParticle*) recovec.at(imaxcaloweight);
+        streamlog_out(DEBUG3) << " get MC particle for cluster " << std::endl;
         const EVENT::LCObjectVec& mcpcalovec = reco2mcNav.getRelatedToObjects(rcpcalo);
-        streamlog_out(DEBUG3) << " mcpcalovec has length " << mcpcalovec.size() << std::endl;  
+        streamlog_out(DEBUG3) << " mcpcalovec has length " << mcpcalovec.size() << std::endl;
         const EVENT::FloatVec& mcpcaloweightvec = reco2mcNav.getRelatedToWeights(rcpcalo);
-        streamlog_out(DEBUG3) << " mcpcaloweightvec has length " << mcpcaloweightvec.size() << std::endl;  
-      
+        streamlog_out(DEBUG3) << " mcpcaloweightvec has length " << mcpcaloweightvec.size() << std::endl;
+
         // check whether calo vector contains original MCP
         for (unsigned imcpcalo = 0; imcpcalo < mcpcalovec.size(); imcpcalo++ ) {
-          if ( mcpcalovec.at(imcpcalo) == mcp ) { 
+          if ( mcpcalovec.at(imcpcalo) == mcp ) {
             mcpcaloweight = double((int(mcpcaloweightvec.at(imcpcalo))/10000)/1000.);
-            streamlog_out(DEBUG3) << " found original MCP in mcpcalovec at position " << imcpcalo << " with weight " << mcpcaloweight << std::endl; 
-          } 
+            streamlog_out(DEBUG3) << " found original MCP in mcpcalovec at position " << imcpcalo << " with weight " << mcpcaloweight << std::endl;
+          }
         }
       }
       else {
-        streamlog_out(DEBUG3) << " imaxcaloweight out of range, skipping backwards check " << std::endl;  
+        streamlog_out(DEBUG3) << " imaxcaloweight out of range, skipping backwards check " << std::endl;
       }
-       
-      
-      // give precedence to track link if both directions larger than 
+
+
+      // give precedence to track link if both directions larger than
       double weightcut = 0.5;
       double maxweight = 0;
       double maxbackweight = 0;
       int imaxweight = -1;
-      
+
       if ( maxtrckweight > weightcut && mcptrckweight > weightcut ) {
         imaxweight = imaxtrckweight;
         maxweight = maxtrckweight;
@@ -337,20 +337,20 @@ void PIDTree::processEvent( LCEvent * evt ) {
         streamlog_out(WARNING) << " maxtrckweight =  " << maxtrckweight << ", mcptrckweight = " << mcptrckweight << std::endl ;
         streamlog_out(WARNING) << " maxcaloweight =  " << maxcaloweight << ", mcpcaloweight = " << mcpcaloweight << std::endl ;
       }
-        
+
       isTrue.push_back(maxbackweight);
       isSeen.push_back(maxweight);
-      
+
       if (maxweight > 0 && imaxweight > -1 && imaxweight < (int) recovec.size()) {
-    
-        ReconstructedParticle* rcp =  (ReconstructedParticle*) recovec.at(imaxweight); 
+
+        ReconstructedParticle* rcp =  (ReconstructedParticle*) recovec.at(imaxweight);
         dd4hep::rec::Vector3D rp( rcp->getMomentum()[0], rcp->getMomentum()[1], rcp->getMomentum()[2] );
         seenP.push_back(rp.r());
         seenPt.push_back(rp.trans());
         seenTheta.push_back(rp.theta());
         seenPhi.push_back(rp.phi());
         seenCharge.push_back(rcp->getCharge());
-    
+
       // IMPROVE HERE: use directly MCTruthTrackRelation and choose track with larger weight for dE/dx
         const EVENT::LCObjectVec& trackvec = mc2trackNav.getRelatedToObjects(mcp);
         streamlog_out(DEBUG3) << " trackvec has length = " << trackvec.size() << " for true PDG " << mcp->getPDG() << std::endl ;
@@ -360,14 +360,14 @@ void PIDTree::processEvent( LCEvent * evt ) {
         double weightdedx = 0.;
         for ( unsigned itrack = 0; itrack < trackvec.size(); itrack++ ) {
           Track *track = (Track *) trackvec.at(itrack);
-          if ( fabs (trackweightvec.at(itrack) - maxtrckweight) < 0.001  ) { 
-            streamlog_out(DEBUG3) << " found track with weight " << trackweightvec.at(itrack) << ", filling dE/dx !" << std::endl; 
+          if ( fabs (trackweightvec.at(itrack) - maxtrckweight) < 0.001  ) {
+            streamlog_out(DEBUG3) << " found track with weight " << trackweightvec.at(itrack) << ", filling dE/dx !" << std::endl;
             dedx = track->getdEdx();
             dedxerr = track->getdEdxError();
             weightdedx = maxtrckweight;
-          } 
+          }
           else {
-            streamlog_out(DEBUG3) << " not taking track with weight " << trackweightvec.at(itrack) << " since difference with maxtrckweight = " << fabs (trackweightvec.at(itrack) - maxtrckweight) << std::endl; 
+            streamlog_out(DEBUG3) << " not taking track with weight " << trackweightvec.at(itrack) << " since difference with maxtrckweight = " << fabs (trackweightvec.at(itrack) - maxtrckweight) << std::endl;
           }
           if (trackvec.size() > 1) {
             streamlog_out(DEBUG3) << " ===> track " << itrack << " has innermost hit at " << track->getRadiusOfInnermostHit () << std::endl ;
@@ -381,12 +381,12 @@ void PIDTree::processEvent( LCEvent * evt ) {
         seenDEdx.push_back(dedx);
         seenDEdxErr.push_back(dedxerr);
         isSeenDEdx.push_back(weightdedx);
-               
-        
+
+
       // Particle IDs
         LCCollection* rpcol = evt->getCollection( _pandoraPFOs ) ;
         PIDHandler *pidh = new PIDHandler(rpcol);
-         
+
         basicPDG.push_back(pidh->getParticleID(rcp, pidh->getAlgorithmID("BasicVariablePID")).getPDG());
         dEdxPDG.push_back(pidh->getParticleID(rcp, pidh->getAlgorithmID("dEdxPID")).getPDG());
         showerPDG.push_back(pidh->getParticleID(rcp, pidh->getAlgorithmID("ShowerShapesPID")).getPDG());
@@ -395,10 +395,10 @@ void PIDTree::processEvent( LCEvent * evt ) {
 
 
 // JL July 25, 2016 : ParticleIDVec does not seem to get filled !!!
-//       
+//
 //         // getParticleIDs ("S" !) gives back a VECTOR of ParticleID objects for all hypotheses, ordered by value
 //         ParticleIDVec likeliPID = pidh->getParticleIDs(rcp, pidh->getAlgorithmID("LikelihoodPID"));
-//         
+//
 //         int hypcounter[5] = {0,0,0,0,0};
 //         streamlog_out(DEBUG3) << " this ParticleIDVec has a size of = " << likeliPID.size() << std::endl;
 //         for (int ihyp = 0; ihyp < likeliPID.size(); ihyp++) {
@@ -427,7 +427,7 @@ void PIDTree::processEvent( LCEvent * evt ) {
 //             default :
 //               streamlog_out(WARNING) << " found unknown PID hypothesis with pdg = " << pdg << std::endl;
 //               break;
-//           }  
+//           }
 //           if (ihyp == likeliPID.size() - 1) {
 //             for (int jhyp = 0; jhyp < 5; jhyp++) {
 //               if (hypcounter[jhyp] != 1) streamlog_out(ERROR) << " found wrong number of hypotheses: hypcounter [" << jhyp << "] = " << hypcounter[jhyp] << std::endl;
@@ -435,7 +435,7 @@ void PIDTree::processEvent( LCEvent * evt ) {
 //           }
 //         }
 
-        
+
         const ParticleID* likeliPID = &(pidh->getParticleID(rcp, pidh->getAlgorithmID("LikelihoodPID")));
         float likelihood[5] = {999.,999.,999.,999.,999};
         if (likeliPID && likeliPID->getParameters().size() > 4 ) {
@@ -444,7 +444,7 @@ void PIDTree::processEvent( LCEvent * evt ) {
             if ( std::isinf(likelihood[ihyp]) ) {
               streamlog_out(DEBUG3) << " likelihood [" << ihyp << "] = " << likelihood[ihyp] << std::endl;
               likelihood[ihyp] = 888.;
-            }  
+            }
           }
           streamlog_out(DEBUG) << " electron hyp = " << likelihood[0] << std::endl;
           streamlog_out(DEBUG) << " muon hyp = "     << likelihood[1] << std::endl;
@@ -455,12 +455,12 @@ void PIDTree::processEvent( LCEvent * evt ) {
         else {
           streamlog_out(DEBUG3) << " likeliPID has = " << likeliPID->getParameters().size() << " parameters " << std::endl;
         }
-        LiPDG_el.push_back(likelihood[0]); 
-        LiPDG_mu.push_back(likelihood[1]); 
-        LiPDG_pi.push_back(likelihood[2]); 
-        LiPDG_ka.push_back(likelihood[3]); 
-        LiPDG_pr.push_back(likelihood[4]); 
-        
+        LiPDG_el.push_back(likelihood[0]);
+        LiPDG_mu.push_back(likelihood[1]);
+        LiPDG_pi.push_back(likelihood[2]);
+        LiPDG_ka.push_back(likelihood[3]);
+        LiPDG_pr.push_back(likelihood[4]);
+
         const ParticleID* dedxPID = &(pidh->getParticleID(rcp, pidh->getAlgorithmID("dEdxPID")));
         float dedxlikeli[5] = {999.,999.,999.,999.,999.};
         float distance[5] = {999.,999.,999.,999.,999.};
@@ -470,11 +470,11 @@ void PIDTree::processEvent( LCEvent * evt ) {
             if ( std::isinf(likelihood[ihyp]) ) {
               streamlog_out(DEBUG3) << " dedxlikeli [" << ihyp << "] = " << dedxlikeli[ihyp] << std::endl;
               dedxlikeli[ihyp] = 888.;
-            }  
+            }
             distance[ihyp] = dedxPID->getParameters()[13+ihyp];
             if ( std::isinf(distance[ihyp]) ) {
               distance[ihyp] = 888.;
-            }  
+            }
             streamlog_out(DEBUG3) << pidh->getParameterNames(pidh->getAlgorithmID("dEdxPID"))[13+ihyp] << " = " << distance[ihyp] << std::endl;
           }
           streamlog_out(DEBUG) << " dEdx liklihood electron hyp = " << dedxlikeli[0] << std::endl;
@@ -486,24 +486,24 @@ void PIDTree::processEvent( LCEvent * evt ) {
         else {
           streamlog_out(DEBUG3) << " dedxPID has = " << dedxPID->getParameters().size() << " parameters " << std::endl;
         }
-        dedxdist_el.push_back(distance[0]); 
-        dedxdist_mu.push_back(distance[1]); 
-        dedxdist_pi.push_back(distance[2]); 
-        dedxdist_ka.push_back(distance[3]); 
-        dedxdist_pr.push_back(distance[4]); 
-        dedxPDG_el.push_back(dedxlikeli[0]); 
-        dedxPDG_mu.push_back(dedxlikeli[1]); 
-        dedxPDG_pi.push_back(dedxlikeli[2]); 
-        dedxPDG_ka.push_back(dedxlikeli[3]); 
-        dedxPDG_pr.push_back(dedxlikeli[4]); 
-        
-        
+        dedxdist_el.push_back(distance[0]);
+        dedxdist_mu.push_back(distance[1]);
+        dedxdist_pi.push_back(distance[2]);
+        dedxdist_ka.push_back(distance[3]);
+        dedxdist_pr.push_back(distance[4]);
+        dedxPDG_el.push_back(dedxlikeli[0]);
+        dedxPDG_mu.push_back(dedxlikeli[1]);
+        dedxPDG_pi.push_back(dedxlikeli[2]);
+        dedxPDG_ka.push_back(dedxlikeli[3]);
+        dedxPDG_pr.push_back(dedxlikeli[4]);
+
+
 
       } // if reco part
       // IMPROVE HERE: CHECK if track or cluster exists!
       else {
         streamlog_out(DEBUG4) << "no ReconstructedParticle found for this mcp with PDG = " << mcp->getPDG() << " ! " << std::endl ;
-        
+
         seenP.push_back(0);
         seenPt.push_back(0);
         seenTheta.push_back(0);
@@ -520,40 +520,40 @@ void PIDTree::processEvent( LCEvent * evt ) {
         LiPDG_pi.push_back(777.);
         LiPDG_ka.push_back(777.);
         LiPDG_pr.push_back(777.);
-        dedxdist_el.push_back(777.); 
-        dedxdist_mu.push_back(777.); 
-        dedxdist_pi.push_back(777.); 
-        dedxdist_ka.push_back(777.); 
-        dedxdist_pr.push_back(777.); 
-        dedxPDG_el.push_back(777.); 
-        dedxPDG_mu.push_back(777.); 
-        dedxPDG_pi.push_back(777.); 
-        dedxPDG_ka.push_back(777.); 
-        dedxPDG_pr.push_back(777.); 
-        
-         
+        dedxdist_el.push_back(777.);
+        dedxdist_mu.push_back(777.);
+        dedxdist_pi.push_back(777.);
+        dedxdist_ka.push_back(777.);
+        dedxdist_pr.push_back(777.);
+        dedxPDG_el.push_back(777.);
+        dedxPDG_mu.push_back(777.);
+        dedxPDG_pi.push_back(777.);
+        dedxPDG_ka.push_back(777.);
+        dedxPDG_pr.push_back(777.);
+
+
       }
-  
+
     }  // if gst == 1
   }  // loop over MCPs
-  
-  
-  hermTree->Fill(); 
+
+
+  hermTree->Fill();
   nEvt++;
 
     if( ! (nEvt % 100)  )
       streamlog_out(MESSAGE)  << "================================ events processed:  " << nEvt << std::endl ;
-  
-}
-
-
-
-void PIDTree::check( LCEvent*) { 
 
 }
 
 
-void PIDTree::end(){ 
+
+void PIDTree::check( LCEvent*) {
+
+}
+
+
+void PIDTree::end(){
 
 }
 


### PR DESCRIPTION
This leaked 256 bytes per particle because of a new without a delete. In my opinion this is small enough for the stack so I've put it there now.

BEGINRELEASENOTES
- fixed memory leak in PIDTree.cc
ENDRELEASENOTES

My editor also automatically removed a lot of trailing whitespace but I could re-add them in case you are unhappy with that amount of change.