### PR TITLE
dEdxAnalyser v1.3

### DIFF
--- a/dEdX/Readme.md
+++ b/dEdX/Readme.md
@@ -2,7 +2,7 @@
 
 Performance plots for dE/dx.
 
-- U. Einhaus, Apr 2021, v1.2
+- U. Einhaus, Dec 2022, v1.3
 
 ## Overview
 
@@ -34,7 +34,7 @@ The FiducialElectrons histograms collects electrons which are similar to electro
 The histogram NormLambdaFullAll_1 contains the mean dE/dx over |lambda| incl. a poly3 fit, which is used in the AngularCorrection_dEdxProcessor for correction of the angular dependence.
 The histogram NormCosThFullAll_1 contains the mean dE/dx over cos(theta), and shows the information of NormLambdaFullAll_1 over an alternative angular scale.
 The Bethe-Bloch curves in BBHist are fitted to provide the parameters of the reference curves for the dEdxPID in the LikelihoodPIDProcessor.
-The fit results are stored with the histograms and also printed on the console at the end of the processor.
+The fit results are stored with the histograms in the root file and also printed on the console at the end of the processor and in a file dEdxAnalyser_CalibrationOutput.txt in the current working directory.
 
 You can run this Analyser over any selection of tracks, e. g. only pion and kaon tracks.
 In that case, only the pion and kaon resolution as well as only the pion-kaon separation would give sensible plots, but all other plots would be generated empty alongside.
@@ -45,23 +45,27 @@ The hit number histograms are unaffected by this.
 
 General processor parameters:
 
-- **plotStuff** - Set to true to switch on automatic image generation of many histograms in the current working directory.
+- **plotStuff** - Set true to switch on automatic image generation of many histograms in the current working directory.
   bool, default: false.
 - **fileFormat** - Select the file extension to be used for the automatically generated images.
   Selection depends on root TPad::Print() capabilities, typically: [.ps, .eps, .pdf, .svg, .tex, .gif, .xpm, .png, .jpg, .tiff, .cxx, .xml, .json, .root].
   See https://root.cern.ch/doc/master/classTPad.html#ad2fc5f449e4cb5480b9fb05fda3a8307 for details.
   string, default: .png
 
-- **usePFOTracks** - Set to true to use tracks attached to charged PFO, instead of all tracks in the track collection. This should be used with events which are more busy than single particle files.
+- **usePFOTracks** - Set true to use tracks attached to charged PFO, instead of all tracks in the track collection. This should be used with events which are more busy than single particle files.
   bool, default: false.
 - **useOneTrack** - Set true if from every event only the first object in the selected collection (track or PFO) should be used. Usually, don't combine this with _usePFOTracks.
+  bool, default: false.
+- **usePFOTruthLink** - Set true if the LCRelation from PFO to MCTruth instead of Track to MCTruth should be used to determine MC PDG. The name of the LCRelation still needs to be set in the TrackMCTruthLink parameter.
   bool, default: false.
 
 You can make a track selection via the optional parameters, e. g. to reduce 'contamination' from mis-linked Tracks and MCParticles.
 
 - **cutdEdx** - Set true if particles with a very off dE/dx value (hard-coded) should be ignored.
   bool, default: false.
-- **cutTrackPurity** - Set true if particles should be ignored, where the MCParticle is connected to more than one track.
+- **cutTrackPurity** - Set true if particles should be ignored, where the dominating MCParticle is connected to more than one track.
+  bool, default: false.
+- **cutTrackPurityMom** - Set true if particles should be ignored, where the dominating MCParticle is connected to more than one track, but the track with the highest momentum should still be used.
   bool, default: false.
 - **cutD0** - Tracks with a d0 larger than the given value will be ignored. Set to 0 to accept all particles.
   double, default: 0.
@@ -73,6 +77,7 @@ You can make a track selection via the optional parameters, e. g. to reduce 'con
   double, default: 0.
  
 For calibration with beam test results, so-called fiducial electrons are selected, which ought to be similar to beam-test conditions, and their properties stored in separate histograms.
+lambda is the track angle with respect to the cathode.
 
 - **fidMomMin** - Fiducial minimum absolut momentum / GeV.
   double, default: 3.

--- a/dEdX/include/dEdxAnalyser.h
+++ b/dEdX/include/dEdxAnalyser.h
@@ -29,7 +29,7 @@ using namespace marlin;
 
 
 /** dEdxAnalyser Processor <br>
- *  The dEdxAnalyser processor loops through tracks to collect their dE/dx, fills various histograms and calculates dE/dx resolution and separation power.
+ *  The dEdxAnalyser processor loops through tracks (directly or via PFOs) to collect their dE/dx, fills various histograms and calculates dE/dx resolution and separation power.
  *  Everything is stored in an AIDA-generated root-file.
  *  Various plots can be automatically produced in the current working directory.
  *
@@ -40,7 +40,7 @@ using namespace marlin;
  *  This version: _nPart = 5; species: electrons, muons, pions, kaon, protons.
  *
  *  First, in processEvent(), the dE/dx value of each track is filled in the corresponding histogram, resulting in Bethe-Bloch curves.
- *  The correct PDG is received from the MCParticle linked to the track.
+ *  The true PDG is received from the MCParticle linked to the track.
  *  In end(), these histograms are then fitted with FitSlices, and the resulting mean and sigma values for each momentum bin are used to calculate resolution and separation power.
  *  The separation power is calculated for each combination of the _nPart species.
  *  All histograms, including the auto-generated fit results, are stored via AIDA in a root file.
@@ -53,9 +53,9 @@ using namespace marlin;
  *  The Bethe-Bloch curves in BBHist are fitted to provide the parameters of the reference curves for the dEdxPID in the LikelihoodPIDProcessor.
  *  The fit results are stored with the histograms and also printed on the console at the end of the processor.
  *
- *  You can run this Analyser over any selection of tracks, e. g. only pion and kaon tracks.
+ *  You can run this Analyser over any selection of tracks, e.g. events that contain only pion and kaon tracks.
  *  In that case, only the pion and kaon resolution as well as only the pion-kaon separation would give sensible plots, but all other plots are be generated empty alongside.
- *  The Analyser has mostly been used to extract the dE/dx performance from single-particle random-momentum files, but also to check e. g. 6f-ttbar events.
+ *  The Analyser has mostly been used to extract the dE/dx performance from single-particle random-momentum files, but also to check e.g. 6f-ttbar events.
  *
  *  Note that the hit energy histograms will only be filled, if the track hits are available, which is usually only the case for REC-files.
  *  The hit number histograms are unaffected by this.
@@ -70,6 +70,8 @@ using namespace marlin;
  *  @param _usePFOTracks - Set to true to use tracks attached to charged PFO, instead of all tracks in the track collection. This should be used with events which are more busy than single particle files.
  *    bool, default: false.
  *  @param _useOneTrack - Set true if from every event only the first object in the selected collection (track or PFO) should be used. Usually, don't combine this with _usePFOTracks.
+ *    bool, default: false.
+ *  @param _usePFOTruthLink - Set true if the LCRelation from PFO to MCTruth instead of Track to MCTruth should be used to determine MC PDG. Caution: the name of this relation still needs to be given in TrackMCTruthLink.
  *    bool, default: false.
  *
  *  You can make a track selection via the optional parameters, e. g. to reduce 'contamination' from mis-linked Tracks and MCParticles.
@@ -113,7 +115,8 @@ using namespace marlin;
  *    double, default: 1e-6.
  *
  *  @author U. Einhaus, DESY
- *  @version $1.2$
+ *  @version $1.3$
+ *  @date 11/2022
  */
 
 
@@ -173,6 +176,7 @@ class dEdxAnalyser : public Processor {
 
   bool _usePFOTracks=false;
   bool _useOneTrack=false;
+  bool _usePFOTruthLink=false;
   bool _cutdEdx=false;
   bool _cutTrackPurity=false;
   bool _cutTrackPurityMom=false;

--- a/dEdX/steer/steer_example.xml
+++ b/dEdX/steer/steer_example.xml
@@ -1,26 +1,3 @@
-<!-- 
-  Top level Marlin steering file defining the ILD reconstruction chain.
-  
-  !! WARNING !! This file may have been generated from 'Marlin -n MarlinstdReco.xml'. 
-  In this case you will find that : 
-  - no <include ref="..."> element is present
-  - some values differ between the constants section and the actual values in the global section or the processor parameter (e.g the compact file).
-    In this case, please refer to values in the global section or the processor parameters and not the constants section ! 
-  
-  Mandatory parameters :
-    * global.LCIOInputFiles : The input lcio input file(s)
-    * constant.lcgeo_DIR : the lcgeo directory must point on the one sourced in your current ilcsoft
-  
-  Optional parameters :
-    * constant.DetectorModel : the detector model to use the pre-defined lcgeo_DIR as ${lcgeo_DIR}/ILD/compact/${DetectorModel}/${DetectorModel}.xml
-    * constant.RunOverlay250GeV (350, 500 or 1000 GeV) : whether to run the background overlay. If set to true, you must ensure that the overlay background files are correctly set 
-    * constant.PandoraSettingsFile : The pandora settings file to use
-    * constant.PidPDFFile : A single root file name for the PID likelihood processor
-    * constant.PidWeightFiles : A list (space separated) of XML files containing weights for low momentum pi/mu separation (from TMVA)
-
-  Author : Remi Ete, DESY
--->
-
 
 <marlin>
   <constants>
@@ -35,7 +12,8 @@
     <constant name="productionfolder" value="/cvmfs/ilc.desy.de/sw/ILDConfig/v02-00-01/StandardConfig/production" />
     <!-- ILD calibration file -->
     <constant name="CalibrationFile" value="${productionfolder}/Calibration/Calibration_${DetectorModel}.xml" />
-	<!-- location of input files -->
+	 
+	  <!-- location of input files -->
     <constant name="inputfolder" value="/pnfs/desy.de/ilc/prod/ilc/mc-opt-3/ild/dst-merged/1-calib/single/ILD_l5_o1_v02_nobg/v02-00-01" />
 	
   
@@ -140,6 +118,8 @@
     
     <parameter name="usePFOTracks" type="bool"> false </parameter>
     <parameter name="useOneTrack" type="bool"> false </parameter>
+    <parameter name="usePFOTruthLink" type="bool"> false </parameter>
+    
     <parameter name="cutdEdx" type="bool"> false </parameter>
     <parameter name="cutTrackPurity" type="bool"> false </parameter>
     <parameter name="cutTrackPurityMom" type="bool"> false </parameter>
@@ -147,13 +127,11 @@
     <parameter name="cutZ0" type="double"> 0 </parameter>
     <parameter name="cutMomMin" type="double"> 0 </parameter>
     <parameter name="cutMomMax" type="double"> 0 </parameter>
-    <parameter name="usePFOTracks" type="bool"> false </parameter>
-    <parameter name="usePFOTracks" type="bool"> false </parameter>
     
     <parameter name="plotStuff" type="bool"> false </parameter>
     <parameter name="fileFormat" type="string"> .png </parameter>
+    <parameter name="useLCTPCStyle" type="bool"> false </parameter>
     
   </processor>
-
   
 </marlin>

--- a/dEdX/steer/steer_example.xml
+++ b/dEdX/steer/steer_example.xml
@@ -9,7 +9,7 @@
     <!-- The full compact file name -->
     <constant name="CompactFile" value="${lcgeo_DIR}/ILD/compact/${DetectorModel}/${DetectorModel}.xml" />
     <!-- location of ILDConfig production folder -->
-    <constant name="productionfolder" value="/cvmfs/ilc.desy.de/sw/ILDConfig/v02-00-01/StandardConfig/production" />
+    <constant name="productionfolder" value="/cvmfs/ilc.desy.de/sw/ILDConfig/v02-03/StandardConfig/production" />
     <!-- ILD calibration file -->
     <constant name="CalibrationFile" value="${productionfolder}/Calibration/Calibration_${DetectorModel}.xml" />
 	 


### PR DESCRIPTION
Updates to the dEdxAnalyser

BEGINRELEASENOTES
  add option to use RecoMCTruthLink instead of Trak2MCTruthLink
  add plots and fits for angular correction and Bethe-Bloch reference curve for LikelihoodPIDProcessor
  add command line output and text file output of above fit results for calibration
ENDRELEASENOTES